### PR TITLE
Webhooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ VOLUME ./scripts
 
 EXPOSE 8080
 EXPOSE 6060
+EXPOSE 9000
 
 CMD [ "./golem" ]

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -24,6 +24,7 @@ VOLUME /scripts
 FROM debian:buster
 
 EXPOSE 8080 40000
+EXPOSE 9000
 
 WORKDIR /
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - "4000:4000"
       - "40000:40000"
       - "6060:6060"
+      - "9000:9000"
     volumes:
       - ./etc:/app/etc
       - ./scripts:/app/scripts

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,6 +24,7 @@ This will be a working document to track major feature development goals for eac
 ## 0.3 Telnet Done Right Milestones
 
 - [ ] Telnet IAC parsing/session handling implementation overhaul
+- [ ] Copyover: allow hot reloading the app server reusing the existing socket file descriptors and restoring sessions
 - [ ] Add a mechanism for NPCs (with flexibility for PCs in future?) to operate shops that players can buy from, sell?
 
 ## 0.4 Telnet Zlib Compression Milestones

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,13 +24,14 @@ This will be a working document to track major feature development goals for eac
 ## 0.3 Telnet Done Right Milestones
 
 - [ ] Telnet IAC parsing/session handling implementation overhaul
-- [ ] Copyover: allow hot reloading the app server reusing the existing socket file descriptors and restoring sessions
 - [ ] Add a mechanism for NPCs (with flexibility for PCs in future?) to operate shops that players can buy from, sell?
+- [ ] Webhook facility for scripting API
 
 ## 0.4 Telnet Zlib Compression Milestones
 
 - [ ] [MCCP2 or MCCP3 support](https://mudhalla.net/tintin/protocols/mccp/)
 - [ ] Find a solution to perform some fuzz testing of the telnet implementation
+- [ ] Copyover: allow hot reloading the app server reusing the existing socket file descriptors and restoring sessions
 - [ ] README subsection for traditional compile and run with existing services
 
 ## 0.5 Online Creation Milestones

--- a/etc/config.json.example
+++ b/etc/config.json.example
@@ -14,5 +14,8 @@
     "profiling": {
         "enabled": true,
         "port": 6060
+    },
+    "web": {
+        "publicRoot": "http://localhost:9000/"
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/getsentry/sentry-go v0.11.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang-migrate/migrate v3.5.4+incompatible // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85q
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/migrations/7_create_webhooks_table.down.sql
+++ b/migrations/7_create_webhooks_table.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE webhook_script;
+DROP TABLE webhooks;

--- a/migrations/7_create_webhooks_table.up.sql
+++ b/migrations/7_create_webhooks_table.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE webhooks (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+
+    `uuid` VARCHAR(255) NOT NULL UNIQUE,
+
+    /* Timestamps */
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW(),
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE webhook_script (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `webhook_id` BIGINT NOT NULL,
+    `script_id` BIGINT NOT NULL,
+
+    /* Timestamps */
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW(),
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (webhook_id) REFERENCES webhook(id),
+    FOREIGN KEY (script_id) REFERENCES scripts(id)
+);

--- a/migrations/7_create_webhooks_table.up.sql
+++ b/migrations/7_create_webhooks_table.up.sql
@@ -20,6 +20,6 @@ CREATE TABLE webhook_script (
     `updated_at` TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW(),
 
     PRIMARY KEY (id),
-    FOREIGN KEY (webhook_id) REFERENCES webhook(id),
+    FOREIGN KEY (webhook_id) REFERENCES webhooks(id),
     FOREIGN KEY (script_id) REFERENCES scripts(id)
 );

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -164,7 +164,7 @@ func do_webhook(ch *Character, arguments string) {
 		output := "{WWebhook management:\r\n" +
 			"{Glist       - {glist all system webhooks\r\n" +
 			"{Gcreate     - {gcreate a system webhook\r\n" +
-			"{Gdelete [#] - {gdelete a webhook by ID (from list){x\r\n\r\n"
+			"{Gdelete [#] - {gdelete a webhook by ID (from {G\"webhook list\"){x\r\n"
 		ch.Send(output)
 		return
 	}
@@ -177,13 +177,13 @@ func do_webhook(ch *Character, arguments string) {
 		var output strings.Builder
 
 		output.WriteString("{YID#   | URL\r\n")
-		output.WriteString("------+------------------------------------------------------------------------------\r\n")
+		output.WriteString("------+------------------------------------------------------------------------\r\n")
 
 		for _, webhook := range ch.Game.webhooks {
 			output.WriteString(fmt.Sprintf("{Y%5d | %s/webhook?key=%s\r\n", webhook.Id, Config.WebConfiguration.PublicRoot, webhook.Uuid))
 		}
 
-		output.WriteString("{x\r\n")
+		output.WriteString("{x")
 		ch.Send(output.String())
 
 	case "create":
@@ -193,7 +193,7 @@ func do_webhook(ch *Character, arguments string) {
 			break
 		}
 
-		ch.Send(fmt.Sprintf("{gSuccessfully created a new webhook with URL: {G%s/webhook?key=%s{x\r\n", Config.WebConfiguration.PublicRoot, webhook.Uuid))
+		ch.Send(fmt.Sprintf("Successfully created a new webhook with URL:\r\n{Y%s/webhook?key=%s{x\r\n", Config.WebConfiguration.PublicRoot, webhook.Uuid))
 
 	case "delete":
 		secondArgument, _ := oneArgument(arguments)

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -159,6 +159,45 @@ func do_wiznet(ch *Character, arguments string) {
 	ch.Send("Wiznet enabled.\r\n")
 }
 
+func do_webhook(ch *Character, arguments string) {
+	if len(arguments) < 1 {
+		output :=
+			`{WWebhook management:\r\n\r\n
+    {Glist       - {glist all system webhooks\r\n
+	{Gcreate     - {gcreate a system webhook\r\n
+	{Gdelete [#] - {gdelete a webhook by ID (from list){x\r\n\r\n`
+		ch.Send(output)
+		return
+	}
+
+	firstArgument, arguments := oneArgument(arguments)
+
+	command := strings.ToLower(firstArgument)
+	switch command {
+	case "list":
+		break
+	case "create":
+		break
+	case "delete":
+		secondArgument, _ := oneArgument(arguments)
+		if secondArgument == "" {
+			ch.Send("Delete requires an ID argument.\r\n")
+			break
+		}
+
+		//id, err := strconv.Atoi(secondArgument)
+		//if err != nil {
+		//	ch.Send("Bad argument, please provider an integer ID.\r\n")
+		//	break
+		//}
+
+		break
+	default:
+		ch.Send("Unrecognized command.\r\n")
+		break
+	}
+}
+
 func do_goto(ch *Character, arguments string) {
 	id, err := strconv.Atoi(arguments)
 	if err != nil || id <= 0 {

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -175,7 +175,18 @@ func do_webhook(ch *Character, arguments string) {
 	command := strings.ToLower(firstArgument)
 	switch command {
 	case "list":
-		break
+		var output strings.Builder
+
+		output.WriteString("{YID#   | URL\r\n")
+		output.WriteString("------+------------------------------------------------------------------\r\n")
+
+		for _, webhook := range ch.Game.webhooks {
+			output.WriteString(fmt.Sprintf("{Y%4d | %s/webhook?key=%s\r\n", webhook.Id, Config.WebConfiguration.PublicRoot, webhook.Uuid))
+		}
+
+		output.WriteString("{x\r\n")
+		ch.Send(output.String())
+
 	case "create":
 		webhook, err := ch.Game.CreateWebhook()
 		if err != nil {

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -183,8 +183,7 @@ func do_webhook(ch *Character, arguments string) {
 			break
 		}
 
-		ch.Send(fmt.Sprintf("{gSuccessfully created a new webhook with URL: {G%s/webhook?key=%s", Config.WebConfiguration.PublicRoot, webhook.Uuid))
-		break
+		ch.Send(fmt.Sprintf("{gSuccessfully created a new webhook with URL: {G%s/webhook?key=%s{x\r\n", Config.WebConfiguration.PublicRoot, webhook.Uuid))
 
 	case "delete":
 		secondArgument, _ := oneArgument(arguments)
@@ -198,11 +197,8 @@ func do_webhook(ch *Character, arguments string) {
 		//	ch.Send("Bad argument, please provider an integer ID.\r\n")
 		//	break
 		//}
-
-		break
 	default:
 		ch.Send("Unrecognized command.\r\n")
-		break
 	}
 }
 

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -176,11 +176,11 @@ func do_webhook(ch *Character, arguments string) {
 	case "list":
 		var output strings.Builder
 
-		output.WriteString("{YID#   | URL\r\n")
+		output.WriteString("{Y  ID# | URL\r\n")
 		output.WriteString("------+------------------------------------------------------------------------\r\n")
 
 		for _, webhook := range ch.Game.webhooks {
-			output.WriteString(fmt.Sprintf("{Y%5d | %s/webhook?key=%s\r\n", webhook.Id, Config.WebConfiguration.PublicRoot, webhook.Uuid))
+			output.WriteString(fmt.Sprintf("{Y%5d | %swebhook?key=%s\r\n", webhook.Id, Config.WebConfiguration.PublicRoot, webhook.Uuid))
 		}
 
 		output.WriteString("{x")
@@ -193,7 +193,7 @@ func do_webhook(ch *Character, arguments string) {
 			break
 		}
 
-		ch.Send(fmt.Sprintf("Successfully created a new webhook with URL:\r\n{Y%s/webhook?key=%s{x\r\n", Config.WebConfiguration.PublicRoot, webhook.Uuid))
+		ch.Send(fmt.Sprintf("Successfully created a new webhook with URL:\r\n{Y%swebhook?key=%s{x\r\n", Config.WebConfiguration.PublicRoot, webhook.Uuid))
 
 	case "delete":
 		secondArgument, _ := oneArgument(arguments)

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -177,7 +177,15 @@ func do_webhook(ch *Character, arguments string) {
 	case "list":
 		break
 	case "create":
+		webhook, err := ch.Game.CreateWebhook()
+		if err != nil {
+			ch.Send(fmt.Sprintf("Something went wrong trying to create a new webhook: %v\r\n", err))
+			break
+		}
+
+		ch.Send(fmt.Sprintf("{gSuccessfully created a new webhook with URL: {G%s/webhook?key=%s", Config.WebConfiguration.PublicRoot, webhook.Uuid))
 		break
+
 	case "delete":
 		secondArgument, _ := oneArgument(arguments)
 		if secondArgument == "" {

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -161,11 +161,10 @@ func do_wiznet(ch *Character, arguments string) {
 
 func do_webhook(ch *Character, arguments string) {
 	if len(arguments) < 1 {
-		output :=
-			`{WWebhook management:\r\n\r\n
-    {Glist       - {glist all system webhooks\r\n
-	{Gcreate     - {gcreate a system webhook\r\n
-	{Gdelete [#] - {gdelete a webhook by ID (from list){x\r\n\r\n`
+		output := "{WWebhook management:\r\n" +
+			"{Glist       - {glist all system webhooks\r\n" +
+			"{Gcreate     - {gcreate a system webhook\r\n" +
+			"{Gdelete [#] - {gdelete a webhook by ID (from list){x\r\n\r\n"
 		ch.Send(output)
 		return
 	}
@@ -178,10 +177,10 @@ func do_webhook(ch *Character, arguments string) {
 		var output strings.Builder
 
 		output.WriteString("{YID#   | URL\r\n")
-		output.WriteString("------+------------------------------------------------------------------\r\n")
+		output.WriteString("------+------------------------------------------------------------------------------\r\n")
 
 		for _, webhook := range ch.Game.webhooks {
-			output.WriteString(fmt.Sprintf("{Y%4d | %s/webhook?key=%s\r\n", webhook.Id, Config.WebConfiguration.PublicRoot, webhook.Uuid))
+			output.WriteString(fmt.Sprintf("{Y%5d | %s/webhook?key=%s\r\n", webhook.Id, Config.WebConfiguration.PublicRoot, webhook.Uuid))
 		}
 
 		output.WriteString("{x\r\n")

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -203,11 +203,27 @@ func do_webhook(ch *Character, arguments string) {
 			break
 		}
 
-		//id, err := strconv.Atoi(secondArgument)
-		//if err != nil {
-		//	ch.Send("Bad argument, please provider an integer ID.\r\n")
-		//	break
-		//}
+		id, err := strconv.Atoi(secondArgument)
+		if err != nil {
+			ch.Send("Bad argument, please provider an integer ID.\r\n")
+			break
+		}
+
+		for _, webhook := range ch.Game.webhooks {
+			if webhook.Id == id {
+				err := ch.Game.DeleteWebhook(webhook)
+				if err != nil {
+					ch.Send(fmt.Sprintf("Something went wrong trying to delete that webhook: %v\r\n", err))
+					return
+				}
+
+				ch.Send("Ok.\r\n")
+				return
+			}
+		}
+
+		ch.Send("A webook with that ID could not be found.\r\n")
+
 	default:
 		ch.Send("Unrecognized command.\r\n")
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -37,11 +37,16 @@ type AppSentryConfiguration struct {
 	Enabled bool   `json:"enabled"`
 }
 
+type AppWebConfiguration struct {
+	PublicRoot string `json:"publicRoot"`
+}
+
 type AppConfiguration struct {
 	Port                   int                       `json:"port"`
 	MySQLConfiguration     AppMySQLConfiguration     `json:"mysql"`
 	SentryConfiguration    AppSentryConfiguration    `json:"sentry"`
 	ProfilingConfiguration AppProfilingConfiguration `json:"profiling"`
+	WebConfiguration       AppWebConfiguration       `json:"web"`
 
 	greeting []byte
 	motd     []byte

--- a/src/game.go
+++ b/src/game.go
@@ -42,8 +42,10 @@ type Game struct {
 	skills  map[uint]*Skill
 	world   map[uint]*Room
 
-	scripts       map[uint]*Script
-	objectScripts map[uint]*Script
+	scripts        map[uint]*Script
+	objectScripts  map[uint]*Script
+	webhookScripts map[int]*Script
+	webhooks       map[string]*Webhook
 
 	register        chan *Client
 	unregister      chan *Client

--- a/src/game.go
+++ b/src/game.go
@@ -150,6 +150,11 @@ func NewGame() (*Game, error) {
 		return nil, err
 	}
 
+	err = game.LoadWebhooks()
+	if err != nil {
+		return nil, err
+	}
+
 	err = game.InitScripting()
 	if err != nil {
 		return nil, err

--- a/src/interp.go
+++ b/src/interp.go
@@ -77,6 +77,7 @@ func init() {
 	CommandTable["purge"] = Command{Name: "purge", CmdFunc: do_purge, MinimumLevel: LevelHero + 2}
 	CommandTable["shutdown"] = Command{Name: "shutdown", CmdFunc: do_shutdown, MinimumLevel: LevelAdmin}
 	CommandTable["zones"] = Command{Name: "zones", CmdFunc: do_zones, MinimumLevel: LevelHero + 1}
+	CommandTable["webhook"] = Command{Name: "webhook", CmdFunc: do_webhook, MinimumLevel: LevelAdmin}
 	CommandTable["wiznet"] = Command{Name: "wiznet", CmdFunc: do_wiznet, MinimumLevel: LevelAdmin}
 
 	/* fight.go */

--- a/src/main.go
+++ b/src/main.go
@@ -34,8 +34,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	/* Spawn the webhook-handling goroutine */
+	go game.handleWebhooks()
+
 	/* Start the game loop */
 	go game.Run()
+
 	log.Printf("Golem is ready to rock and roll on port %d.\r\n", Config.Port)
 
 	/* Spawn a new goroutine for each new client. */

--- a/src/scripting.go
+++ b/src/scripting.go
@@ -52,6 +52,7 @@ func (game *Game) DefaultSourceLoader(filename string) ([]byte, error) {
 func (game *Game) LoadScriptsFromDatabase() error {
 	game.scripts = make(map[uint]*Script)
 	game.objectScripts = make(map[uint]*Script)
+	game.webhookScripts = make(map[int]*Script)
 
 	rows, err := game.db.Query(`
 		SELECT
@@ -217,6 +218,37 @@ func (game *Game) LoadScriptsFromDatabase() error {
 		}
 
 		plane.Scripts = game.scripts[scriptId]
+	}
+
+	log.Println("Loading webhook-script relations from database...")
+	rows, err = game.db.Query(`
+		SELECT
+			webhook_script.webhook_id,
+			webhook_script.script_id
+		FROM
+			plane_script
+	`)
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var webhookId int
+		var scriptId uint
+
+		err := rows.Scan(&webhookId, &scriptId)
+		if err != nil {
+			return err
+		}
+
+		_, ok := game.scripts[scriptId]
+		if !ok {
+			return errors.New("tried to load a webhook_script for a nonexistent script")
+		}
+
+		game.webhookScripts[webhookId] = game.scripts[scriptId]
 	}
 
 	return nil

--- a/src/scripting.go
+++ b/src/scripting.go
@@ -226,7 +226,7 @@ func (game *Game) LoadScriptsFromDatabase() error {
 			webhook_script.webhook_id,
 			webhook_script.script_id
 		FROM
-			plane_script
+			webhook_script
 	`)
 	if err != nil {
 		return err

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -52,8 +52,22 @@ func (game *Game) LoadWebhooks() error {
 }
 
 func (game *Game) handleWebhooks() {
+	defer func() {
+		recover()
+	}()
+
 	http.HandleFunc("/webhook", func(w http.ResponseWriter, req *http.Request) {
-		log.Printf("Got a webhook request with key: %s\r\n", req.URL.Query().Get("key"))
+		keyParam := req.URL.Query().Get("key")
+
+		if len(keyParam) != 4 {
+			log.Printf("Got a webhook request with BAD key: %s\r\n", keyParam)
+			return
+		}
+
+		log.Printf("Got a webhook request with key: %s\r\n", keyParam)
+
+		game.webhookMessage <- keyParam
+
 	})
 
 	http.ListenAndServe(":9000", nil)

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -73,6 +73,7 @@ func (game *Game) DeleteWebhook(webhook *Webhook) error {
 		return nil
 	}
 
+	delete(game.webhooks, webhook.Uuid)
 	return nil
 }
 

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 James Skarzinskas.
+ * All rights reserved.
+ * See LICENSE.txt in project root for license information.
+ * Authors:
+ *     James Skarzinskas <james@jskarzin.org>
+ */
+package main
+
+import (
+	"log"
+)
+
+type Webhook struct {
+	Id  int    `json:"id"`
+	Url string `json:"url"`
+}
+
+func (game *Game) LoadWebhooks() error {
+	log.Printf("Loading webhooks.\r\n")
+
+	rows, err := game.db.Query(`
+		SELECT
+			id,
+			url
+		FROM
+			webhooks
+	`)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		webhook := &Webhook{}
+
+		err := rows.Scan(&webhook.Id, &webhook.Url)
+		if err != nil {
+			log.Printf("Unable to scan webhook: %v.\r\n", err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -9,20 +9,23 @@ package main
 
 import (
 	"log"
+	"net/http"
 )
 
 type Webhook struct {
-	Id  int    `json:"id"`
-	Url string `json:"url"`
+	Id   int    `json:"id"`
+	Uuid string `json:"uuid"`
 }
 
 func (game *Game) LoadWebhooks() error {
 	log.Printf("Loading webhooks.\r\n")
 
+	game.webhooks = make(map[string]*Webhook)
+
 	rows, err := game.db.Query(`
 		SELECT
 			id,
-			url
+			uuid
 		FROM
 			webhooks
 	`)
@@ -36,12 +39,22 @@ func (game *Game) LoadWebhooks() error {
 	for rows.Next() {
 		webhook := &Webhook{}
 
-		err := rows.Scan(&webhook.Id, &webhook.Url)
+		err := rows.Scan(&webhook.Id, &webhook.Uuid)
 		if err != nil {
 			log.Printf("Unable to scan webhook: %v.\r\n", err)
 			return err
 		}
+
+		game.webhooks[webhook.Uuid] = webhook
 	}
 
 	return nil
+}
+
+func (game *Game) handleWebhooks() {
+	http.HandleFunc("/webhook", func(w http.ResponseWriter, req *http.Request) {
+		log.Printf("Got a webhook request with key: %s\r\n", req.URL.Query().Get("key"))
+	})
+
+	http.ListenAndServe(":9000", nil)
 }

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -120,9 +120,7 @@ func (game *Game) handleWebhooks() {
 		}
 
 		log.Printf("Got a webhook request with key: %s\r\n", keyParam)
-
 		game.webhookMessage <- keyParam
-
 	})
 
 	http.ListenAndServe(":9000", nil)

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -53,6 +53,10 @@ func (game *Game) LoadWebhooks() error {
 	return nil
 }
 
+func (game *Game) DeleteWebhook(*Webhook) error {
+	return nil
+}
+
 func (game *Game) CreateWebhook() (*Webhook, error) {
 	webhookUuid, err := uuid.NewUUID()
 	if err != nil {

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -115,8 +115,8 @@ func (game *Game) handleWebhooks() {
 	http.HandleFunc("/webhook", func(w http.ResponseWriter, req *http.Request) {
 		keyParam := req.URL.Query().Get("key")
 
-		if len(keyParam) != 4 {
-			log.Printf("Got a webhook request with BAD key: %s\r\n", keyParam)
+		if len(keyParam) != 36 {
+			log.Print("Ignoring a webhook key submitted without a length of 36.\r\n")
 			return
 		}
 

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -53,7 +53,26 @@ func (game *Game) LoadWebhooks() error {
 	return nil
 }
 
-func (game *Game) DeleteWebhook(*Webhook) error {
+func (game *Game) DeleteWebhook(webhook *Webhook) error {
+	result, err := game.db.Exec(`
+	DELETE FROM
+		webhooks
+	WHERE
+		id = ?`, webhook.Id)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected != 1 {
+		/* Weird, but not fatal */
+		return nil
+	}
+
 	return nil
 }
 

--- a/src/webhooks.go
+++ b/src/webhooks.go
@@ -19,6 +19,8 @@ type Webhook struct {
 	Uuid string `json:"uuid"`
 }
 
+const WebhookKeyLength = 36
+
 func (game *Game) LoadWebhooks() error {
 	log.Printf("Loading webhooks.\r\n")
 
@@ -115,7 +117,7 @@ func (game *Game) handleWebhooks() {
 	http.HandleFunc("/webhook", func(w http.ResponseWriter, req *http.Request) {
 		keyParam := req.URL.Query().Get("key")
 
-		if len(keyParam) != 36 {
+		if len(keyParam) != WebhookKeyLength {
 			log.Print("Ignoring a webhook key submitted without a length of 36.\r\n")
 			return
 		}


### PR DESCRIPTION
- Migration to add `webhooks` and `webhook_script` tables
- `do_webhook` admin command to create, list, and delete webhook entities
- If a 36-character string is received as the URL key param on the HTTP listener, emit a webhookMessage in the game thread and try to invoke the scripting handler through the `webhook_script` if one is attached to this, invoking `onGET` with the game object as `this`
- Adds a `web` key to the config structure and example JSON with a configurable `publicRoot` for correctly forming the generated webhook URLs