### PR TITLE
Refactor updating of ObjectInstances, combat bug fix

### DIFF
--- a/scripts/combat.js
+++ b/scripts/combat.js
@@ -15,7 +15,7 @@ function onCombatUpdate() {
             for (let i = 0; i < combat.participants.length; i++) {
                 const vch = combat.participants[i];
 
-                if (vch.Room === null) {
+                if(!vch.room) {
                     continue;
                 }
 

--- a/src/act_comm.go
+++ b/src/act_comm.go
@@ -114,6 +114,20 @@ func do_quit(ch *Character, arguments string) {
 	})
 
 	ch.Game.Characters.Remove(ch)
+	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
+		obj := iter.Value.(*ObjectInstance)
+
+		if obj.Contents != nil {
+			for innerIter := obj.Contents.Head; innerIter != nil; innerIter = innerIter.Next {
+				containedObj := innerIter.Value.(*ObjectInstance)
+
+				ch.Game.Objects.Remove(containedObj)
+			}
+		}
+
+		ch.Game.Objects.Remove(obj)
+	}
+
 	ch.Client.ConnectionState = ConnectionStateNone
 	ch.Send("{WLeaving for the real world...{x\r\n")
 

--- a/src/act_obj.go
+++ b/src/act_obj.go
@@ -754,6 +754,7 @@ func do_take(ch *Character, arguments string) {
 		ch.addObject(found)
 	} else {
 		ch.Gold = ch.Gold + found.Value0
+		ch.Game.Objects.Remove(found)
 	}
 
 	ch.Send(fmt.Sprintf("You take %s{x.\r\n", found.ShortDescription))
@@ -904,6 +905,7 @@ func do_drop(ch *Character, arguments string) {
 		ch.Gold -= amount
 		gold := ch.Game.CreateGold(amount)
 		ch.Room.Objects.Insert(gold)
+		ch.Game.Objects.Insert(gold)
 
 		ch.Send(fmt.Sprintf("You drop %s.\r\n", gold.GetShortDescription(ch)))
 

--- a/src/act_obj.go
+++ b/src/act_obj.go
@@ -10,6 +10,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -136,16 +137,17 @@ func (ch *Character) examineObject(obj *ObjectInstance) {
 			minuteSuffix = ""
 		}
 
-		if obj.Ttl == 1 {
+		objExpiry := int(math.Max(time.Until(obj.CreatedAt.Add(time.Duration(obj.Ttl)*time.Minute)).Minutes(), 0))
+		if objExpiry == 1 {
 			ttlSuffix = ""
 		}
 
-		output.WriteString(fmt.Sprintf("{Y* {C%s{c was created %d minute%s ago and will%svanish after {C%d{c minute%s has passed.\r\n",
+		output.WriteString(fmt.Sprintf("{Y* {C%s{c was created %d minute%s ago and will%svanish in {C%d{c minute%s.\r\n",
 			obj.GetShortDescriptionUpper(ch),
 			int(time.Since(obj.CreatedAt).Minutes()),
 			minuteSuffix,
 			silentString,
-			obj.Ttl,
+			objExpiry,
 			ttlSuffix,
 		))
 	}
@@ -703,6 +705,7 @@ func do_take(ch *Character, arguments string) {
 			ch.addObject(takingObj)
 		} else {
 			ch.Gold = ch.Gold + takingObj.Value0
+			ch.Game.Objects.Remove(takingObj)
 		}
 
 		ch.Send(fmt.Sprintf("You take %s{x from %s{x.\r\n", takingObj.GetShortDescription(ch), takingFrom.GetShortDescription(ch)))

--- a/src/character.go
+++ b/src/character.go
@@ -489,6 +489,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 		}
 
 		ch.addObject(obj)
+		ch.Game.Objects.Remove(obj)
 	}
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
@@ -535,6 +536,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 			}
 
 			obj.addObject(containedObj)
+			ch.Game.Objects.Remove(containedObj)
 		}
 	}
 

--- a/src/character.go
+++ b/src/character.go
@@ -489,7 +489,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 		}
 
 		ch.addObject(obj)
-		ch.Game.Objects.Remove(obj)
+		ch.Game.Objects.Insert(obj)
 	}
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
@@ -536,7 +536,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 			}
 
 			obj.addObject(containedObj)
-			ch.Game.Objects.Remove(containedObj)
+			ch.Game.Objects.Insert(containedObj)
 		}
 	}
 

--- a/src/fight.go
+++ b/src/fight.go
@@ -88,6 +88,8 @@ func (game *Game) createCorpse(ch *Character) *ObjectInstance {
 		gobj := game.CreateGold(ch.Gold)
 		if gobj != nil {
 			obj.Contents.Insert(gobj)
+
+			ch.Game.Objects.Insert(gobj)
 		}
 	} else {
 		obj.Contents = NewLinkedList()
@@ -149,12 +151,16 @@ func (game *Game) Damage(ch *Character, target *Character, display bool, amount 
 			room := target.Room
 
 			corpse := game.createCorpse(target)
-			room.removeCharacter(target)
 
+			room.removeCharacter(target)
 			room.addObject(corpse)
+
+			ch.Game.Objects.Insert(corpse)
 
 			blood := game.createBlood(1)
 			room.addObject(blood)
+
+			ch.Game.Objects.Insert(blood)
 
 			target.Fighting = nil
 			target.Combat = nil

--- a/src/game.go
+++ b/src/game.go
@@ -203,7 +203,7 @@ func (game *Game) Run() {
 	processCharacterUpdateTicker := time.NewTicker(2 * time.Second)
 
 	/* Handle object update logic */
-	processObjectUpdateTicker := time.NewTicker(1 * time.Minute)
+	processObjectUpdateTicker := time.NewTicker(15 * time.Second)
 
 	/* Buffered/paged output for clients */
 	processOutputTicker := time.NewTicker(50 * time.Millisecond)

--- a/src/game.go
+++ b/src/game.go
@@ -30,6 +30,7 @@ type Game struct {
 	db *sql.DB
 	vm *goja.Runtime
 
+	Objects      *LinkedList `json:"objects"`
 	Characters   *LinkedList `json:"characters"`
 	Fights       *LinkedList `json:"fights"`
 	Planes       *LinkedList `json:"planes"`
@@ -81,6 +82,7 @@ func NewGame() (*Game, error) {
 
 	game.Characters = NewLinkedList()
 	game.Fights = NewLinkedList()
+	game.Objects = NewLinkedList()
 	game.ScriptTimers = NewLinkedList()
 	game.Planes = NewLinkedList()
 

--- a/src/game.go
+++ b/src/game.go
@@ -202,6 +202,9 @@ func (game *Game) Run() {
 	/* Handle frequent character update logic */
 	processCharacterUpdateTicker := time.NewTicker(2 * time.Second)
 
+	/* Handle object update logic */
+	processObjectUpdateTicker := time.NewTicker(1 * time.Minute)
+
 	/* Buffered/paged output for clients */
 	processOutputTicker := time.NewTicker(50 * time.Millisecond)
 
@@ -219,6 +222,9 @@ func (game *Game) Run() {
 
 		case <-processZoneUpdateTicker.C:
 			game.ZoneUpdate()
+
+		case <-processObjectUpdateTicker.C:
+			game.objectUpdate()
 
 		case <-processCharacterUpdateTicker.C:
 			game.characterUpdate()

--- a/src/shop.go
+++ b/src/shop.go
@@ -250,6 +250,7 @@ func do_buy(ch *Character, arguments string) {
 			}
 
 			ch.addObject(obj)
+			ch.Game.Objects.Insert(obj)
 			ch.Gold -= listing.Price
 			return
 		}

--- a/src/update.go
+++ b/src/update.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -17,6 +18,36 @@ func (game *Game) characterUpdate() {
 
 		if ch.Casting != nil {
 			ch.onCastingUpdate()
+		}
+	}
+}
+
+func (game *Game) objectUpdate() {
+	for iter := game.Objects.Head; iter != nil; iter = iter.Next {
+		obj := iter.Value.(*ObjectInstance)
+
+		/* Remove the obj after its ttl time in minutes, if the ITEM_DECAYS flag is set */
+		if obj.Flags&ITEM_DECAYS != 0 && int(time.Since(obj.CreatedAt).Minutes()) > obj.Ttl {
+			if obj.Flags&ITEM_DECAY_SILENTLY == 0 {
+				for innerIter := obj.InRoom.Characters.Head; innerIter != nil; innerIter = innerIter.Next {
+					rch := innerIter.Value.(*Character)
+
+					rch.Send(fmt.Sprintf("{D%s{D crumbles into dust.{x\r\n", obj.GetShortDescriptionUpper(rch)))
+				}
+			}
+
+			/* If the object is a container, try to transfer all of its contents to the room */
+			if obj.ItemType == ItemTypeContainer && obj.Contents != nil {
+				for contentIter := obj.Contents.Head; contentIter != nil; contentIter = contentIter.Next {
+					contentObj := contentIter.Value.(*ObjectInstance)
+
+					obj.removeObject(contentObj)
+					obj.InRoom.addObject(contentObj)
+				}
+			}
+
+			obj.InRoom.removeObject(obj)
+			game.Objects.Remove(obj)
 		}
 	}
 }

--- a/src/update.go
+++ b/src/update.go
@@ -27,7 +27,7 @@ func (game *Game) objectUpdate() {
 		obj := iter.Value.(*ObjectInstance)
 
 		/* Remove the obj after its ttl time in minutes, if the ITEM_DECAYS flag is set */
-		if obj.Flags&ITEM_DECAYS != 0 && int(time.Since(obj.CreatedAt).Minutes()) > obj.Ttl {
+		if obj.Flags&ITEM_DECAYS != 0 && int(time.Since(obj.CreatedAt).Minutes()) >= obj.Ttl {
 			if obj.Flags&ITEM_DECAY_SILENTLY == 0 {
 				for innerIter := obj.InRoom.Characters.Head; innerIter != nil; innerIter = innerIter.Next {
 					rch := innerIter.Value.(*Character)

--- a/src/zone.go
+++ b/src/zone.go
@@ -93,6 +93,7 @@ func (game *Game) ResetRoom(room *Room) {
 				}
 
 				room.addObject(obj)
+				game.Objects.Insert(obj)
 			}
 
 		case ResetTypeMobile:
@@ -131,33 +132,6 @@ func (game *Game) ResetRoom(room *Room) {
 
 		if room.Zone.ResetMessage != "" && character.Flags&CHAR_IS_PLAYER != 0 {
 			character.Send(fmt.Sprintf("\r\n{x%s{x\r\n", room.Zone.ResetMessage))
-		}
-	}
-
-	for iter := room.Objects.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
-
-		/* Remove the obj after its ttl time in minutes, if the ITEM_DECAYS flag is set */
-		if obj.Flags&ITEM_DECAYS != 0 && int(time.Since(obj.CreatedAt).Minutes()) > obj.Ttl {
-			if obj.Flags&ITEM_DECAY_SILENTLY == 0 {
-				for innerIter := room.Characters.Head; innerIter != nil; innerIter = innerIter.Next {
-					rch := innerIter.Value.(*Character)
-
-					rch.Send(fmt.Sprintf("{D%s{D crumbles into dust.{x\r\n", obj.GetShortDescriptionUpper(rch)))
-				}
-			}
-
-			/* If the object is a container, try to transfer all of its contents to the room */
-			if obj.ItemType == ItemTypeContainer && obj.Contents != nil {
-				for contentIter := obj.Contents.Head; contentIter != nil; contentIter = contentIter.Next {
-					contentObj := contentIter.Value.(*ObjectInstance)
-
-					obj.removeObject(contentObj)
-					room.addObject(contentObj)
-				}
-			}
-
-			room.removeObject(obj)
 		}
 	}
 }


### PR DESCRIPTION
**Features:**

- Move logic for updating `ObjectInstance`s from `Game.ResetRoom` to `Game.objectUpdate` to decouple object updates from zone resets
- Add a 15s ticker to invoke `Game.objectUpdate`

**Fixes:**

- Null check on combat participant's room preventing disposal of old combat and creating accumulated participations to weird effect