### PR TITLE
Defer inserting player inventory into game object list

### DIFF
--- a/src/character.go
+++ b/src/character.go
@@ -489,7 +489,6 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 		}
 
 		ch.addObject(obj)
-		ch.Game.Objects.Insert(obj)
 	}
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
@@ -536,7 +535,6 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 			}
 
 			obj.addObject(containedObj)
-			ch.Game.Objects.Insert(containedObj)
 		}
 	}
 

--- a/src/nanny.go
+++ b/src/nanny.go
@@ -354,6 +354,20 @@ func (game *Game) nanny(client *Client, message string) {
 
 		game.Characters.Insert(client.Character)
 
+		for iter := client.Character.Inventory.Head; iter != nil; iter = iter.Next {
+			obj := iter.Value.(*ObjectInstance)
+
+			game.Objects.Insert(obj)
+
+			if obj.Contents != nil {
+				for innerIter := obj.Contents.Head; innerIter != nil; innerIter = innerIter.Next {
+					containedObj := innerIter.Value.(*ObjectInstance)
+
+					game.Objects.Insert(containedObj)
+				}
+			}
+		}
+
 		if client.Character.Room != nil {
 			client.Character.Room.AddCharacter(client.Character)
 


### PR DESCRIPTION
- Defer inserting player inventory into game object list until session confirmed, preventing memory leak from discarded login attempts