### PR TITLE
Introduce PlaneObservers and add Character.Trail room history

### DIFF
--- a/scripts/editor/StringEditor.js
+++ b/scripts/editor/StringEditor.js
@@ -6,7 +6,7 @@
  *     James Skarzinskas <james@jskarzin.org>
  */
 Golem.StringEditor = function (client, string, callback) {
-    let _string = string;
+    let _string = String(string);
     let cursor = string.match(/[^\r\n]+/g).length;
 
     const commit = () => (string = String(_string));
@@ -61,7 +61,7 @@ Golem.StringEditor = function (client, string, callback) {
                 client.connectionHandler = null;
 
                 ch.send("{YExiting without writing changes.{x\r\n");
-                callback(client, _string);
+                callback(client, string);
             } else if(input === '!') {
                 ch.send("{YContents of the string editor buffer:{x\r\n");
 

--- a/src/character.go
+++ b/src/character.go
@@ -118,6 +118,7 @@ type Character struct {
 	inputCursor  int
 
 	PlaneIndex *Point          `json:"planeIndex"`
+	Trail      []*Room         `json:"trail"`
 	Room       *Room           `json:"room"`
 	Combat     *Combat         `json:"combat"`
 	Fighting   *Character      `json:"fighting"`
@@ -1057,6 +1058,7 @@ func NewCharacter() *Character {
 	character.Combat = nil
 	character.Race = nil
 	character.Room = nil
+	character.Trail = make([]*Room, 0)
 	character.PlaneIndex = nil
 	character.Wiznet = false
 	character.Practices = 0


### PR DESCRIPTION
https://user-images.githubusercontent.com/5122630/144718441-ca9d91ba-3587-4297-9066-f96a04e65f38.mp4

Introduces a first take on plane observers, an abstraction allowing scripts to register geofencing event handlers in the game's "plane" maps, "observing" a rectangle emitting events on entities passing in and out of its boundary.

Example usage registering the observer displayed in the video:

```js
plane.map.layers[0].registerObserver(Golem.util.newRect2D(20, 400, 8, 8), {}, function () {
    const output = "{C" + this.getShortDescriptionUpper(this) + " entered the observer field at (" + this.room.x + ", " + this.room.y + "){x\r\n";

    Golem.game.broadcast(output);
}, function () {
    const output = "{C" + this.getShortDescriptionUpper(this) + " left the observer field at (" + this.trail[0].x + ", " + this.trail[0].y + "){x\r\n";

    Golem.game.broadcast(output);
});
```