### PR TITLE
feat: use generics for linked lists

### DIFF
--- a/src/a_star.go
+++ b/src/a_star.go
@@ -145,7 +145,7 @@ func (maze *MazeGrid) findPathAStar(start *MazeCell, end *MazeCell) []*MazeAStar
 			} else {
 				neighbours := currentNode.cell.getAdjacentCells(false, 1, false)
 				for iter := neighbours.Head; iter != nil; iter = iter.Next {
-					neighbour := iter.Value.(*MazeCell)
+					neighbour := iter.Value
 
 					if !visited[neighbour] {
 						var gScore int = currentNode.gScore + 1

--- a/src/act_comm.go
+++ b/src/act_comm.go
@@ -55,7 +55,7 @@ func do_say(ch *Character, arguments string) {
 
 	if ch.Room != nil {
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			rch := iter.Value.(*Character)
+			rch := iter.Value
 
 			if rch != ch {
 				rch.Send(output)
@@ -118,11 +118,11 @@ func do_quit(ch *Character, arguments string) {
 
 	ch.Game.Characters.Remove(ch)
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		if obj.Contents != nil {
 			for innerIter := obj.Contents.Head; innerIter != nil; innerIter = innerIter.Next {
-				containedObj := innerIter.Value.(*ObjectInstance)
+				containedObj := innerIter.Value
 
 				ch.Game.Objects.Remove(containedObj)
 			}
@@ -147,7 +147,7 @@ func (ch *Character) DisbandGroup() {
 	ch.Send("{WYou disband your group.{x\r\n")
 
 	for iter := ch.Group.Head; iter != nil; iter = iter.Next {
-		gch := iter.Value.(*Character)
+		gch := iter.Value
 		gch.Group = nil
 		gch.Leader = nil
 
@@ -161,7 +161,7 @@ func (ch *Character) leaveGroup() {
 	ch.leaveGroupFrom(nil)
 }
 
-func (ch *Character) leaveGroupFrom(group *LinkedList[interface{}]) {
+func (ch *Character) leaveGroupFrom(group *LinkedList[*Character]) {
 	if group != nil {
 		group.Remove(ch)
 	}
@@ -191,7 +191,7 @@ func do_group(ch *Character, arguments string) {
 		output.WriteString(fmt.Sprintf("{W%s{W's group:{x\r\n", ch.Leader.GetShortDescriptionUpper(ch)))
 
 		for iter := ch.Group.Head; iter != nil; iter = iter.Next {
-			gch := iter.Value.(*Character)
+			gch := iter.Value
 
 			output.WriteString(fmt.Sprintf("[%2d %-8s] %-14s %5d/%5dhp %5d/%5dm %5d/%5dst\r\n",
 				gch.Level,
@@ -230,7 +230,7 @@ func do_group(ch *Character, arguments string) {
 		ch.Send(fmt.Sprintf("{WYou leave %s{W's group.{x\r\n", ch.Leader.GetShortDescription(ch)))
 
 		for iter := ch.Group.Head; iter != nil; iter = iter.Next {
-			gch := iter.Value.(*Character)
+			gch := iter.Value
 
 			if gch != ch {
 				gch.Send(fmt.Sprintf("{W%s{W leaves the group.{x\r\n", ch.GetShortDescriptionUpper(gch)))
@@ -247,7 +247,7 @@ func do_group(ch *Character, arguments string) {
 	}
 
 	if ch.Group == nil {
-		ch.Group = NewAnyLinkedList()
+		ch.Group = NewLinkedList[*Character]()
 		ch.Group.Insert(ch)
 		ch.Leader = ch
 	}

--- a/src/act_comm.go
+++ b/src/act_comm.go
@@ -161,7 +161,7 @@ func (ch *Character) leaveGroup() {
 	ch.leaveGroupFrom(nil)
 }
 
-func (ch *Character) leaveGroupFrom(group *LinkedList) {
+func (ch *Character) leaveGroupFrom(group *LinkedList[interface{}]) {
 	if group != nil {
 		group.Remove(ch)
 	}
@@ -247,7 +247,7 @@ func do_group(ch *Character, arguments string) {
 	}
 
 	if ch.Group == nil {
-		ch.Group = NewLinkedList()
+		ch.Group = NewAnyLinkedList()
 		ch.Group.Insert(ch)
 		ch.Leader = ch
 	}

--- a/src/act_info.go
+++ b/src/act_info.go
@@ -210,7 +210,7 @@ func do_affect(ch *Character, arguments string) {
 	buf.WriteString("{MYou are affected by the following enchantments:{x\r\n")
 
 	for effect := ch.Effects.Head; effect != nil; effect = effect.Next {
-		fx := effect.Value.(*Effect)
+		fx := effect.Value
 
 		switch fx.EffectType {
 		case EffectTypeStat:
@@ -461,7 +461,7 @@ func do_look(ch *Character, arguments string) {
 				foundCh.Send(fmt.Sprintf("{G%s{G looks at you.{x\r\n", ch.GetShortDescriptionUpper(foundCh)))
 
 				for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-					rch := iter.Value.(*Character)
+					rch := iter.Value
 
 					if rch != ch && rch != foundCh {
 						rch.Send(fmt.Sprintf("{G%s{G looks at %s{G.{x\r\n", ch.GetShortDescriptionUpper(rch), foundCh.GetShortDescription(rch)))

--- a/src/act_move.go
+++ b/src/act_move.go
@@ -551,7 +551,7 @@ func (ch *Character) move(direction uint, follow bool) bool {
 
 	from.moveCharacter(ch, destination)
 	for iter := from.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 		character.Send(fmt.Sprintf("{W%s{W leaves %s.{x\r\n", ch.GetShortDescriptionUpper(character), ExitName[direction]))
 	}
 
@@ -560,7 +560,7 @@ func (ch *Character) move(direction uint, follow bool) bool {
 	}
 
 	for iter := destination.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 		if character != ch {
 			character.Send(fmt.Sprintf("{W%s{W arrives from %s.{x\r\n", ch.GetShortDescriptionUpper(character), ExitName[ReverseDirection[direction]]))
 		}
@@ -573,7 +573,7 @@ func (ch *Character) move(direction uint, follow bool) bool {
 	}
 
 	for iter := from.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 
 		if character.Following == ch {
 			character.Send(fmt.Sprintf("{WYou follow %s{W.{x\r\n", ch.GetShortDescription(character)))
@@ -587,7 +587,7 @@ func (ch *Character) move(direction uint, follow bool) bool {
 
 	/* Aggro check... */
 	for iter := destination.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 
 		if character != ch {
 			/* If the entering player is a PC, this is a hostile NPC, and that hostile NPC is not currently preoccupied with another combat, then let's rum	ble. */
@@ -639,7 +639,7 @@ func do_close(ch *Character, arguments string) {
 			ch.Send(fmt.Sprintf("You close %s{x.\r\n", obj.GetShortDescription(ch)))
 
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if !rch.IsEqual(ch) {
 					rch.Send(fmt.Sprintf("{W%s{W closes %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -671,7 +671,7 @@ func do_close(ch *Character, arguments string) {
 	ch.Send("You close the door.\r\n")
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch != ch {
 			rch.Send(fmt.Sprintf("{W%s{W closes the door %s.{x\r\n", ch.GetShortDescriptionUpper(rch), ExitName[exit.Direction]))
@@ -679,7 +679,7 @@ func do_close(ch *Character, arguments string) {
 	}
 
 	for iter := exit.To.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 		character.Send(fmt.Sprintf("{WThe %s door closes.{x\r\n", ExitName[ReverseDirection[exit.Direction]]))
 	}
 }
@@ -728,7 +728,7 @@ func do_open(ch *Character, arguments string) {
 			ch.Send(fmt.Sprintf("You open %s{x.\r\n", obj.GetShortDescription(ch)))
 
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if !rch.IsEqual(ch) {
 					rch.Send(fmt.Sprintf("{W%s{W opens %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -763,7 +763,7 @@ func do_open(ch *Character, arguments string) {
 	ch.Send("You open the door.\r\n")
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if !rch.IsEqual(ch) {
 			rch.Send(fmt.Sprintf("{W%s{W opens the door %s.{x\r\n", ch.GetShortDescriptionUpper(rch), ExitName[exit.Direction]))
@@ -771,7 +771,7 @@ func do_open(ch *Character, arguments string) {
 	}
 
 	for iter := exit.To.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 		character.Send(fmt.Sprintf("{WThe %s door opens.{x\r\n", ExitName[ReverseDirection[exit.Direction]]))
 	}
 }

--- a/src/act_obj.go
+++ b/src/act_obj.go
@@ -72,7 +72,7 @@ func objectListDescription(obj *ObjectInstance, viewer *Character, longDescripti
 	return buf.String()
 }
 
-func (ch *Character) listObjects(objects *LinkedList, longDescriptions bool, hideEquipped bool) {
+func (ch *Character) listObjects(objects *LinkedList[interface{}], longDescriptions bool, hideEquipped bool) {
 	var output strings.Builder
 	var inventory map[string]uint = make(map[string]uint)
 

--- a/src/act_obj.go
+++ b/src/act_obj.go
@@ -72,7 +72,7 @@ func objectListDescription(obj *ObjectInstance, viewer *Character, longDescripti
 	return buf.String()
 }
 
-func (ch *Character) listObjects(objects *LinkedList[interface{}], longDescriptions bool, hideEquipped bool) {
+func (ch *Character) listObjects(objects *LinkedList[*ObjectInstance], longDescriptions bool, hideEquipped bool) {
 	var output strings.Builder
 	var inventory map[string]uint = make(map[string]uint)
 
@@ -81,7 +81,7 @@ func (ch *Character) listObjects(objects *LinkedList[interface{}], longDescripti
 	}
 
 	for iter := objects.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		if hideEquipped && obj.WearLocation != -1 {
 			continue
@@ -98,7 +98,7 @@ func (ch *Character) listObjects(objects *LinkedList[interface{}], longDescripti
 	}
 
 	for iter := objects.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		if hideEquipped && obj.WearLocation != -1 {
 			continue
@@ -130,7 +130,7 @@ func sendToRoomExcept(ch *Character, message func(rch *Character) string) {
 	}
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 		if rch.IsEqual(ch) {
 			continue
 		}
@@ -286,7 +286,7 @@ func (ch *Character) examineObject(obj *ObjectInstance) {
 
 func (ch *Character) GetEquipment(wearLocation int) *ObjectInstance {
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		if obj.WearLocation == wearLocation {
 			return obj
@@ -371,7 +371,7 @@ func do_wear(ch *Character, arguments string) {
 	firstArgument, _ := OneArgument(arguments)
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		if obj.WearLocation == -1 {
 			if strings.Contains(obj.Name, firstArgument) {
@@ -391,7 +391,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You hold %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x holds %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -416,7 +416,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wield %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wields %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -441,7 +441,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -466,7 +466,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -491,7 +491,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -516,7 +516,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -541,7 +541,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -566,7 +566,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -591,7 +591,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -616,7 +616,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -641,7 +641,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -666,7 +666,7 @@ func do_wear(ch *Character, arguments string) {
 						ch.Send(fmt.Sprintf("You wear %s{x.\r\n", obj.GetShortDescription(ch)))
 
 						for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-							rch := roomOthersIter.Value.(*Character)
+							rch := roomOthersIter.Value
 
 							if !rch.IsEqual(ch) {
 								rch.Send(fmt.Sprintf("%s{x wears %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -692,7 +692,7 @@ func do_remove(ch *Character, arguments string) {
 	firstArgument, _ := OneArgument(arguments)
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		if obj.WearLocation != -1 {
 			if strings.Contains(obj.Name, firstArgument) {
@@ -701,7 +701,7 @@ func do_remove(ch *Character, arguments string) {
 					ch.Send(fmt.Sprintf("You remove %s{x.\r\n", obj.GetShortDescription(ch)))
 
 					for roomOthersIter := ch.Room.Characters.Head; roomOthersIter != nil; roomOthersIter = roomOthersIter.Next {
-						rch := roomOthersIter.Value.(*Character)
+						rch := roomOthersIter.Value
 
 						if !rch.IsEqual(ch) {
 							rch.Send(fmt.Sprintf("%s{x removes %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -773,7 +773,7 @@ func do_fill(ch *Character, arguments string) {
 
 	var fountain *ObjectInstance
 	for iter := ch.Room.Objects.Head; iter != nil; iter = iter.Next {
-		roomObj := iter.Value.(*ObjectInstance)
+		roomObj := iter.Value
 		if roomObj.ItemType == ItemTypeFountain {
 			fountain = roomObj
 			break
@@ -821,7 +821,7 @@ func do_drink(ch *Character, arguments string) {
 	if arg == "" {
 		if ch.Room.Objects != nil {
 			for iter := ch.Room.Objects.Head; iter != nil; iter = iter.Next {
-				roomObj := iter.Value.(*ObjectInstance)
+				roomObj := iter.Value
 				if roomObj.ItemType == ItemTypeFountain {
 					obj = roomObj
 					break
@@ -1048,7 +1048,7 @@ func do_put(ch *Character, arguments string) {
 	ch.Send(fmt.Sprintf("You put %s{x inside of %s{x.\r\n", placingObj.GetShortDescription(ch), placingIn.GetShortDescription(ch)))
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch != ch {
 			rch.Send(fmt.Sprintf("%s{x puts %s{x inside of %s{x.\r\n", ch.GetShortDescriptionUpper(rch), placingObj.GetShortDescription(rch), placingIn.GetShortDescription(rch)))
@@ -1099,7 +1099,7 @@ func do_take(ch *Character, arguments string) {
 			}
 
 			for iter := takingFrom.Contents.Head; iter != nil; iter = iter.Next {
-				takingObj := iter.Value.(*ObjectInstance)
+				takingObj := iter.Value
 
 				if takingObj.Flags&ITEM_TAKE == 0 {
 					continue
@@ -1134,7 +1134,7 @@ func do_take(ch *Character, arguments string) {
 
 				ch.Send(fmt.Sprintf("You take %s{x from %s{x.\r\n", takingObj.GetShortDescription(ch), takingFrom.GetShortDescription(ch)))
 				for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-					rch := iter.Value.(*Character)
+					rch := iter.Value
 
 					if rch != ch {
 						rch.Send(fmt.Sprintf("%s{x takes %s{x from %s{x.\r\n", ch.GetShortDescriptionUpper(rch), takingObj.GetShortDescription(rch), takingFrom.GetShortDescription(rch)))
@@ -1184,7 +1184,7 @@ func do_take(ch *Character, arguments string) {
 
 			ch.Send(fmt.Sprintf("You take %s{x from %s{x.\r\n", takingObj.GetShortDescription(ch), takingFrom.GetShortDescription(ch)))
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if rch != ch {
 					rch.Send(fmt.Sprintf("%s{x takes %s{x from %s{x.\r\n", ch.GetShortDescriptionUpper(rch), takingObj.GetShortDescription(rch), takingFrom.GetShortDescription(rch)))
@@ -1197,7 +1197,7 @@ func do_take(ch *Character, arguments string) {
 
 	if firstArgument == "all" {
 		for iter := ch.Room.Objects.Head; iter != nil; iter = iter.Next {
-			found := iter.Value.(*ObjectInstance)
+			found := iter.Value
 
 			if found.Flags&ITEM_TAKE == 0 {
 				continue
@@ -1241,7 +1241,7 @@ func do_take(ch *Character, arguments string) {
 
 			if ch.Room != nil {
 				for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-					rch := iter.Value.(*Character)
+					rch := iter.Value
 
 					if rch != ch {
 						rch.Send(outString)
@@ -1302,7 +1302,7 @@ func do_take(ch *Character, arguments string) {
 
 	if ch.Room != nil {
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			rch := iter.Value.(*Character)
+			rch := iter.Value
 
 			if rch != ch {
 				rch.Send(outString)
@@ -1360,7 +1360,7 @@ func do_give(ch *Character, arguments string) {
 
 		if ch.Room != nil {
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if rch != ch && rch != target {
 					rch.Send(fmt.Sprintf("\r\n%s{x gives %s{x to %s{x.\r\n", ch.GetShortDescriptionUpper(rch), goldRepresentation.GetShortDescription(rch), target.GetShortDescription(rch)))
@@ -1412,7 +1412,7 @@ func do_give(ch *Character, arguments string) {
 
 	if ch.Room != nil {
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			rch := iter.Value.(*Character)
+			rch := iter.Value
 
 			if rch != ch && rch != target {
 				rch.Send(fmt.Sprintf("\r\n%s{x gives %s{x to %s{x.\r\n", ch.GetShortDescriptionUpper(rch), found.GetShortDescription(rch), target.GetShortDescription(rch)))
@@ -1438,7 +1438,7 @@ func do_drop(ch *Character, arguments string) {
 		objects := make([]*ObjectInstance, 0)
 
 		for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-			obj := iter.Value.(*ObjectInstance)
+			obj := iter.Value
 
 			if obj.WearLocation == -1 {
 				objects = append(objects, obj)
@@ -1467,7 +1467,7 @@ func do_drop(ch *Character, arguments string) {
 			ch.Send(fmt.Sprintf("You drop %s{x.\r\n", obj.GetShortDescription(ch)))
 
 			for roomIter := ch.Room.Characters.Head; roomIter != nil; roomIter = roomIter.Next {
-				rch := roomIter.Value.(*Character)
+				rch := roomIter.Value
 
 				if !rch.IsEqual(ch) {
 					rch.Send(fmt.Sprintf("%s{x drops %s{x.\r\n", ch.GetShortDescriptionUpper(rch), obj.GetShortDescription(rch)))
@@ -1500,7 +1500,7 @@ func do_drop(ch *Character, arguments string) {
 		var found *ObjectInstance = nil
 
 		for iter := ch.Room.Objects.Head; iter != nil; iter = iter.Next {
-			obj := iter.Value.(*ObjectInstance)
+			obj := iter.Value
 
 			if obj.ItemType == ItemTypeCurrency {
 				found = obj
@@ -1524,7 +1524,7 @@ func do_drop(ch *Character, arguments string) {
 		ch.Game.Objects.Insert(gold)
 
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			rch := iter.Value.(*Character)
+			rch := iter.Value
 
 			if !rch.IsEqual(ch) {
 				rch.Send(fmt.Sprintf("\r\n%s drops %s{x.\r\n", ch.GetShortDescriptionUpper(rch), gold.GetShortDescription(rch)))
@@ -1558,7 +1558,7 @@ func do_drop(ch *Character, arguments string) {
 	outString := fmt.Sprintf("\r\n%s drops %s{x.\r\n", ch.Name, found.ShortDescription)
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch != ch {
 			rch.Send(outString)

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -42,7 +42,7 @@ func do_zones(ch *Character, arguments string) {
 		"Min. Since"))
 
 	for iter := ch.Game.Zones.Head; iter != nil; iter = iter.Next {
-		zone := iter.Value.(*Zone)
+		zone := iter.Value
 
 		minutesSinceZoneReset := int(time.Since(zone.LastReset).Minutes())
 
@@ -78,7 +78,7 @@ func do_mlist(ch *Character, arguments string) {
 	output.WriteString(fmt.Sprintf("Displaying all %d character instances in the world:\r\n", ch.Game.Characters.Count))
 
 	for iter := ch.Game.Characters.Head; iter != nil; iter = iter.Next {
-		wch := iter.Value.(*Character)
+		wch := iter.Value
 
 		if wch.Flags&CHAR_IS_PLAYER != 0 {
 			if wch.Client != nil {
@@ -518,7 +518,7 @@ func do_goto(ch *Character, arguments string) {
 
 		var found *Plane = nil
 		for iter := ch.Game.Planes.Head; iter != nil; iter = iter.Next {
-			plane := iter.Value.(*Plane)
+			plane := iter.Value
 
 			if plane.Id == id {
 				found = plane
@@ -570,7 +570,7 @@ func do_goto(ch *Character, arguments string) {
 	var room *Room = nil
 
 	for iter := ch.Game.Characters.Head; iter != nil; iter = iter.Next {
-		gch := iter.Value.(*Character)
+		gch := iter.Value
 
 		nameParts := strings.Split(gch.Name, " ")
 		for _, part := range nameParts {

--- a/src/act_wiz.go
+++ b/src/act_wiz.go
@@ -101,7 +101,7 @@ func do_purge(ch *Character, arguments string) {
 
 	for iter := ch.Room.Characters.Head; iter != nil; {
 		next := iter.Next
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 		if rch == ch || rch.Client != nil || rch.Flags&CHAR_IS_PLAYER != 0 {
 			iter = next
 			continue
@@ -116,14 +116,14 @@ func do_purge(ch *Character, arguments string) {
 			break
 		}
 
-		obj := ch.Room.Objects.Head.Value.(*ObjectInstance)
+		obj := ch.Room.Objects.Head.Value
 		ch.Game.removeObjectFromWorld(obj)
 	}
 
 	ch.Send("You have purged the contents of the room.\r\n")
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if !rch.IsEqual(ch) {
 			rch.Send(fmt.Sprintf("%s purges the contents of the room.\r\n", ch.GetShortDescriptionUpper(rch)))
@@ -137,7 +137,7 @@ func do_peace(ch *Character, arguments string) {
 	}
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		rch.Flags &= ^CHAR_AGGRESSIVE
 		rch.Fighting = nil
@@ -545,7 +545,7 @@ func do_goto(ch *Character, arguments string) {
 
 		if ch.Room != nil && ch.Room.Characters != nil {
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				character := iter.Value.(*Character)
+				character := iter.Value
 				if character != ch {
 					character.Send(fmt.Sprintf("\r\n{W%s{W disappears in a puff of smoke.{x\r\n", ch.GetShortDescriptionUpper(character)))
 				}
@@ -556,7 +556,7 @@ func do_goto(ch *Character, arguments string) {
 			ch.Room.moveCharacter(ch, destination)
 
 			for iter := destination.Characters.Head; iter != nil; iter = iter.Next {
-				character := iter.Value.(*Character)
+				character := iter.Value
 				if character != ch {
 					character.Send(fmt.Sprintf("\r\n{W%s{W appears in a puff of smoke.{x\r\n", ch.GetShortDescriptionUpper(character)))
 				}
@@ -602,7 +602,7 @@ func do_goto(ch *Character, arguments string) {
 
 	if ch.Room != nil {
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			character := iter.Value.(*Character)
+			character := iter.Value
 			if character != ch {
 				character.Send(fmt.Sprintf("\r\n{W%s{W disappears in a puff of smoke.{x\r\n", ch.GetShortDescriptionUpper(character)))
 			}
@@ -614,7 +614,7 @@ func do_goto(ch *Character, arguments string) {
 	}
 
 	for iter := room.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 		if character != ch {
 			character.Send(fmt.Sprintf("\r\n{W%s{W appears in a puff of smoke.{x\r\n", ch.GetShortDescriptionUpper(character)))
 		}

--- a/src/character.go
+++ b/src/character.go
@@ -184,7 +184,7 @@ type Character struct {
 	Game   *Game   `json:"game"`
 	Client *Client `json:"client"`
 
-	Inventory *LinkedList[interface{}] `json:"inventory"`
+	Inventory *LinkedList[*ObjectInstance] `json:"inventory"`
 
 	output       []byte
 	outputCursor int
@@ -201,9 +201,9 @@ type Character struct {
 	Casting    *CastingContext `json:"casting"`
 	Furniture  *ObjectInstance `json:"furniture"`
 
-	Following *Character               `json:"following"`
-	Leader    *Character               `json:"leader"`
-	Group     *LinkedList[interface{}] `json:"group"`
+	Following *Character              `json:"following"`
+	Leader    *Character              `json:"leader"`
+	Group     *LinkedList[*Character] `json:"group"`
 
 	Id int `json:"id"`
 
@@ -221,9 +221,9 @@ type Character struct {
 	Experience uint `json:"experience"`
 	Practices  int  `json:"practices"`
 
-	Affected int                      `json:"affected"`
-	Effects  *LinkedList[interface{}] `json:"effects"`
-	Skills   map[uint]*Proficiency    `json:"skills"`
+	Affected int                   `json:"affected"`
+	Effects  *LinkedList[*Effect]  `json:"effects"`
+	Skills   map[uint]*Proficiency `json:"skills"`
 
 	Gold  int               `json:"gold"`
 	Flags int               `json:"flags"`
@@ -576,7 +576,7 @@ func (ch *Character) GetStat(stat int) (int, int) {
 	var modifiedSum int = 0
 
 	for iter := ch.Effects.Head; iter != nil; iter = iter.Next {
-		fx := iter.Value.(*Effect)
+		fx := iter.Value
 
 		if fx.EffectType != EffectTypeStat || fx.Location != stat {
 			continue
@@ -888,7 +888,7 @@ func (ch *Character) DetachAllObjects() int {
 
 	if ch.Inventory != nil {
 		for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-			obj := iter.Value.(*ObjectInstance)
+			obj := iter.Value
 			obj.resetObjectInstanceIDs()
 		}
 	}
@@ -1108,12 +1108,12 @@ func (game *Game) SavePlayerInventory(ch *Character) error {
 
 	/* Iterate over all objects in this player's inventory */
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		/* If this is a container, ensure that all contained object instances are also updated */
 		if obj.Contents != nil && obj.Contents.Count > 0 {
 			for containerIter := obj.Contents.Head; containerIter != nil; containerIter = containerIter.Next {
-				containedObj := containerIter.Value.(*ObjectInstance)
+				containedObj := containerIter.Value
 
 				updating = append(updating, containedObj)
 			}
@@ -1236,7 +1236,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 	for rows.Next() {
 		obj := &ObjectInstance{
 			Game:         game,
-			Contents:     NewAnyLinkedList(),
+			Contents:     NewLinkedList[*ObjectInstance](),
 			Inside:       nil,
 			CarriedBy:    nil,
 			WearLocation: -1,
@@ -1258,7 +1258,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 	}
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		rows, err := game.db.Query(`
 			SELECT
@@ -1291,7 +1291,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 		for rows.Next() {
 			containedObj := &ObjectInstance{
 				Game:         game,
-				Contents:     NewAnyLinkedList(),
+				Contents:     NewLinkedList[*ObjectInstance](),
 				Inside:       nil,
 				CarriedBy:    nil,
 				WearLocation: -1,
@@ -1453,13 +1453,13 @@ func (game *Game) addPlayerCharacterToWorld(ch *Character) {
 	game.Characters.Insert(ch)
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		game.Objects.Insert(obj)
 
 		if obj.Contents != nil {
 			for innerIter := obj.Contents.Head; innerIter != nil; innerIter = innerIter.Next {
-				containedObj := innerIter.Value.(*ObjectInstance)
+				containedObj := innerIter.Value
 
 				game.Objects.Insert(containedObj)
 			}
@@ -1674,7 +1674,7 @@ func (ch *Character) getCarryWeight() float64 {
 
 	var total float64
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 		total += obj.GetTotalWeight()
 	}
 
@@ -1873,7 +1873,7 @@ func (obj *ObjectInstance) findObjectInSelf(ch *Character, argument string) *Obj
 	}
 
 	for iter := obj.Contents.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		nameParts := strings.Split(obj.Name, " ")
 		for _, part := range nameParts {
@@ -1908,7 +1908,7 @@ func (ch *Character) FindObjectInRoom(argument string) *ObjectInstance {
 	}
 
 	for iter := ch.Room.Objects.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		nameParts := strings.Split(obj.Name, " ")
 		for _, part := range nameParts {
@@ -1942,7 +1942,7 @@ func (ch *Character) FindObjectOnSelf(argument string) *ObjectInstance {
 	}
 
 	for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		if obj.WearLocation != -1 {
 			continue
@@ -1988,7 +1988,7 @@ func (ch *Character) FindCharacterInRoom(argument string) *Character {
 	}
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		nameParts := strings.Split(rch.Name, " ")
 		for _, part := range nameParts {
@@ -2092,8 +2092,8 @@ func NewCharacter() *Character {
 	character.Client = nil
 	character.Level = 0
 	character.Experience = 0
-	character.Inventory = NewAnyLinkedList()
-	character.Effects = NewAnyLinkedList()
+	character.Inventory = NewLinkedList[*ObjectInstance]()
+	character.Effects = NewLinkedList[*Effect]()
 	character.Skills = make(map[uint]*Proficiency)
 	character.Conditions[ConditionDrunk] = 0
 	character.Conditions[ConditionFull] = ConditionMaximum

--- a/src/character.go
+++ b/src/character.go
@@ -49,13 +49,13 @@ func parseIndexedArgument(argument string) (int, string, bool) {
 }
 
 type Job struct {
-	Id                         uint                     `json:"id"`
-	Name                       string                   `json:"name"`
-	DisplayName                string                   `json:"display_name"`
-	Playable                   bool                     `json:"playable"`
-	ExperienceRequiredModifier float64                  `json:"experience_required_modifier"`
-	Skills                     *LinkedList[interface{}] `json:"skills"`
-	PrimaryAttribute           int                      `json:"primaryAttribute"`
+	Id                         uint                   `json:"id"`
+	Name                       string                 `json:"name"`
+	DisplayName                string                 `json:"display_name"`
+	Playable                   bool                   `json:"playable"`
+	ExperienceRequiredModifier float64                `json:"experience_required_modifier"`
+	Skills                     *LinkedList[*JobSkill] `json:"skills"`
+	PrimaryAttribute           int                    `json:"primaryAttribute"`
 }
 
 type Race struct {

--- a/src/character.go
+++ b/src/character.go
@@ -2012,7 +2012,7 @@ func (game *Game) Broadcast(message string, filter goja.Callable) {
 	for iter := game.Characters.Head; iter != nil; iter = iter.Next {
 		var result bool = false
 
-		ch := iter.Value.(*Character)
+		ch := iter.Value
 
 		if filter != nil {
 			val, err := filter(game.vm.ToValue(ch))
@@ -2045,7 +2045,7 @@ func (game *Game) broadcast(message string, filterFn func(*Character) bool) {
 	for iter := game.Characters.Head; iter != nil; iter = iter.Next {
 		var result bool = false
 
-		ch := iter.Value.(*Character)
+		ch := iter.Value
 
 		if filterFn != nil {
 			result = filterFn(ch)

--- a/src/character.go
+++ b/src/character.go
@@ -49,13 +49,13 @@ func parseIndexedArgument(argument string) (int, string, bool) {
 }
 
 type Job struct {
-	Id                         uint        `json:"id"`
-	Name                       string      `json:"name"`
-	DisplayName                string      `json:"display_name"`
-	Playable                   bool        `json:"playable"`
-	ExperienceRequiredModifier float64     `json:"experience_required_modifier"`
-	Skills                     *LinkedList `json:"skills"`
-	PrimaryAttribute           int         `json:"primaryAttribute"`
+	Id                         uint                     `json:"id"`
+	Name                       string                   `json:"name"`
+	DisplayName                string                   `json:"display_name"`
+	Playable                   bool                     `json:"playable"`
+	ExperienceRequiredModifier float64                  `json:"experience_required_modifier"`
+	Skills                     *LinkedList[interface{}] `json:"skills"`
+	PrimaryAttribute           int                      `json:"primaryAttribute"`
 }
 
 type Race struct {
@@ -184,7 +184,7 @@ type Character struct {
 	Game   *Game   `json:"game"`
 	Client *Client `json:"client"`
 
-	Inventory *LinkedList `json:"inventory"`
+	Inventory *LinkedList[interface{}] `json:"inventory"`
 
 	output       []byte
 	outputCursor int
@@ -201,9 +201,9 @@ type Character struct {
 	Casting    *CastingContext `json:"casting"`
 	Furniture  *ObjectInstance `json:"furniture"`
 
-	Following *Character  `json:"following"`
-	Leader    *Character  `json:"leader"`
-	Group     *LinkedList `json:"group"`
+	Following *Character               `json:"following"`
+	Leader    *Character               `json:"leader"`
+	Group     *LinkedList[interface{}] `json:"group"`
 
 	Id int `json:"id"`
 
@@ -221,9 +221,9 @@ type Character struct {
 	Experience uint `json:"experience"`
 	Practices  int  `json:"practices"`
 
-	Affected int                   `json:"affected"`
-	Effects  *LinkedList           `json:"effects"`
-	Skills   map[uint]*Proficiency `json:"skills"`
+	Affected int                      `json:"affected"`
+	Effects  *LinkedList[interface{}] `json:"effects"`
+	Skills   map[uint]*Proficiency    `json:"skills"`
 
 	Gold  int               `json:"gold"`
 	Flags int               `json:"flags"`
@@ -1236,7 +1236,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 	for rows.Next() {
 		obj := &ObjectInstance{
 			Game:         game,
-			Contents:     NewLinkedList(),
+			Contents:     NewAnyLinkedList(),
 			Inside:       nil,
 			CarriedBy:    nil,
 			WearLocation: -1,
@@ -1291,7 +1291,7 @@ func (game *Game) LoadPlayerInventory(ch *Character) error {
 		for rows.Next() {
 			containedObj := &ObjectInstance{
 				Game:         game,
-				Contents:     NewLinkedList(),
+				Contents:     NewAnyLinkedList(),
 				Inside:       nil,
 				CarriedBy:    nil,
 				WearLocation: -1,
@@ -2092,8 +2092,8 @@ func NewCharacter() *Character {
 	character.Client = nil
 	character.Level = 0
 	character.Experience = 0
-	character.Inventory = NewLinkedList()
-	character.Effects = NewLinkedList()
+	character.Inventory = NewAnyLinkedList()
+	character.Effects = NewAnyLinkedList()
 	character.Skills = make(map[uint]*Proficiency)
 	character.Conditions[ConditionDrunk] = 0
 	character.Conditions[ConditionFull] = ConditionMaximum

--- a/src/client.go
+++ b/src/client.go
@@ -430,7 +430,7 @@ func (client *Client) drainSendQueue() error {
 
 func (game *Game) checkReconnect(client *Client, name string) bool {
 	for iter := game.Characters.Head; iter != nil; iter = iter.Next {
-		ch := iter.Value.(*Character)
+		ch := iter.Value
 
 		if ch.Flags&CHAR_IS_PLAYER != 0 && ch.Name == name {
 			client.Character = nil

--- a/src/client.go
+++ b/src/client.go
@@ -444,7 +444,7 @@ func (game *Game) checkReconnect(client *Client, name string) bool {
 
 			if ch.Room != nil {
 				for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-					character := iter.Value.(*Character)
+					character := iter.Value
 
 					if character != ch {
 						character.Send(fmt.Sprintf("\r\n{M%s has reconnected.{x\r\n", ch.GetShortDescriptionUpper(character)))

--- a/src/copyover.go
+++ b/src/copyover.go
@@ -372,7 +372,7 @@ func (game *Game) recoverCopyoverClient(savedClient copyoverClientState) error {
 
 	if ch.Room != nil {
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			rch := iter.Value.(*Character)
+			rch := iter.Value
 			if rch != ch {
 				rch.Send(fmt.Sprintf("\r\n{W%s materializes.{x\r\n", ch.GetShortDescriptionUpper(rch)))
 			}

--- a/src/db.go
+++ b/src/db.go
@@ -14,8 +14,8 @@ import (
 )
 
 var TerrainTable map[int]*Terrain
-var Jobs *LinkedList
-var Races *LinkedList
+var Jobs *LinkedList[interface{}]
+var Races *LinkedList[interface{}]
 
 func (game *Game) LoadTerrain() error {
 	log.Printf("Loading terrain types.\r\n")
@@ -63,7 +63,7 @@ func (game *Game) LoadTerrain() error {
 func (game *Game) LoadRaceTable() error {
 	log.Printf("Loading races.\r\n")
 
-	Races = NewLinkedList()
+	Races = NewAnyLinkedList()
 
 	rows, err := game.db.Query(`
 		SELECT
@@ -108,7 +108,7 @@ func (game *Game) LoadRaceTable() error {
 func (game *Game) LoadJobTable() error {
 	log.Printf("Loading jobs.\r\n")
 
-	Jobs = NewLinkedList()
+	Jobs = NewAnyLinkedList()
 
 	rows, err := game.db.Query(`
 		SELECT
@@ -139,7 +139,7 @@ func (game *Game) LoadJobTable() error {
 			continue
 		}
 
-		job.Skills = NewLinkedList()
+		job.Skills = NewAnyLinkedList()
 		job.PrimaryAttribute = FindStatByName(primaryAttribute)
 		Jobs.Insert(job)
 	}

--- a/src/db.go
+++ b/src/db.go
@@ -14,8 +14,8 @@ import (
 )
 
 var TerrainTable map[int]*Terrain
-var Jobs *LinkedList[interface{}]
-var Races *LinkedList[interface{}]
+var Jobs *LinkedList[*Job]
+var Races *LinkedList[*Race]
 
 func (game *Game) LoadTerrain() error {
 	log.Printf("Loading terrain types.\r\n")
@@ -63,7 +63,7 @@ func (game *Game) LoadTerrain() error {
 func (game *Game) LoadRaceTable() error {
 	log.Printf("Loading races.\r\n")
 
-	Races = NewAnyLinkedList()
+	Races = NewLinkedList[*Race]()
 
 	rows, err := game.db.Query(`
 		SELECT
@@ -108,7 +108,7 @@ func (game *Game) LoadRaceTable() error {
 func (game *Game) LoadJobTable() error {
 	log.Printf("Loading jobs.\r\n")
 
-	Jobs = NewAnyLinkedList()
+	Jobs = NewLinkedList[*Job]()
 
 	rows, err := game.db.Query(`
 		SELECT
@@ -139,7 +139,7 @@ func (game *Game) LoadJobTable() error {
 			continue
 		}
 
-		job.Skills = NewAnyLinkedList()
+		job.Skills = NewLinkedList[*JobSkill]()
 		job.PrimaryAttribute = FindStatByName(primaryAttribute)
 		Jobs.Insert(job)
 	}
@@ -214,7 +214,7 @@ func (game *Game) LoadJobSkills() error {
 /* Utility lookup methods */
 func FindJobByName(name string) *Job {
 	for iter := Jobs.Head; iter != nil; iter = iter.Next {
-		job := iter.Value.(*Job)
+		job := iter.Value
 
 		if strings.Compare(name, job.Name) == 0 {
 			return job
@@ -226,7 +226,7 @@ func FindJobByName(name string) *Job {
 
 func FindRaceByName(name string) *Race {
 	for iter := Races.Head; iter != nil; iter = iter.Next {
-		race := iter.Value.(*Race)
+		race := iter.Value
 
 		if strings.Compare(name, race.Name) == 0 {
 			return race
@@ -238,7 +238,7 @@ func FindRaceByName(name string) *Race {
 
 func FindJobByID(id uint) *Job {
 	for iter := Jobs.Head; iter != nil; iter = iter.Next {
-		job := iter.Value.(*Job)
+		job := iter.Value
 
 		if job.Id == id {
 			return job
@@ -250,7 +250,7 @@ func FindJobByID(id uint) *Job {
 
 func FindRaceByID(id uint) *Race {
 	for iter := Races.Head; iter != nil; iter = iter.Next {
-		race := iter.Value.(*Race)
+		race := iter.Value
 
 		if race.Id == id {
 			return race

--- a/src/effect.go
+++ b/src/effect.go
@@ -114,10 +114,7 @@ func (ch *Character) HasEffect(fx *Effect) bool {
 	}
 
 	for effect := ch.Effects.Head; effect != nil; effect = effect.Next {
-		existing, ok := effect.Value.(*Effect)
-		if !ok {
-			continue
-		}
+		existing := effect.Value
 
 		if existing.Matches(fx) {
 			return true
@@ -154,7 +151,7 @@ func (ch *Character) refreshAffected() {
 	}
 
 	for effect := ch.Effects.Head; effect != nil; effect = effect.Next {
-		fx := effect.Value.(*Effect)
+		fx := effect.Value
 		if fx.EffectType == EffectTypeAffected {
 			ch.Affected |= fx.Bits
 		}

--- a/src/fight.go
+++ b/src/fight.go
@@ -83,7 +83,7 @@ func (game *Game) combatForCharacter(ch *Character) *Combat {
 	}
 
 	for iter := game.Fights.Head; iter != nil; iter = iter.Next {
-		combat := iter.Value.(*Combat)
+		combat := iter.Value
 		if combat.hasParticipant(ch) {
 			return combat
 		}
@@ -102,7 +102,7 @@ func (game *Game) AddCombatParticipant(combat *Combat, ch *Character) {
 
 	if game != nil && game.Fights != nil {
 		for iter := game.Fights.Head; iter != nil; iter = iter.Next {
-			existing := iter.Value.(*Combat)
+			existing := iter.Value
 			if existing == combat {
 				continue
 			}
@@ -282,7 +282,7 @@ func (game *Game) participatedInKill(ch *Character, target *Character) bool {
 	}
 
 	for iter := game.Fights.Head; iter != nil; iter = iter.Next {
-		combat := iter.Value.(*Combat)
+		combat := iter.Value
 		if combat.hasParticipant(ch) && combat.hasParticipant(target) {
 			return true
 		}

--- a/src/fight.go
+++ b/src/fight.go
@@ -233,7 +233,7 @@ func (game *Game) createCorpse(ch *Character) *ObjectInstance {
 	obj.Ttl = 20
 	obj.WearLocation = -1
 
-	obj.Contents = NewLinkedList()
+	obj.Contents = NewAnyLinkedList()
 	if ch.Inventory != nil {
 		carriedObjects := make([]*ObjectInstance, 0, ch.Inventory.Count)
 		for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
@@ -425,7 +425,7 @@ func (game *Game) Damage(ch *Character, target *Character, display bool, amount 
 
 				limbo.AddCharacter(target)
 
-				target.Effects = NewLinkedList()
+				target.Effects = NewAnyLinkedList()
 				target.refreshAffected()
 				target.Health = target.MaxHealth / 8
 				target.Mana = 1

--- a/src/fight.go
+++ b/src/fight.go
@@ -233,11 +233,11 @@ func (game *Game) createCorpse(ch *Character) *ObjectInstance {
 	obj.Ttl = 20
 	obj.WearLocation = -1
 
-	obj.Contents = NewAnyLinkedList()
+	obj.Contents = NewLinkedList[*ObjectInstance]()
 	if ch.Inventory != nil {
 		carriedObjects := make([]*ObjectInstance, 0, ch.Inventory.Count)
 		for iter := ch.Inventory.Head; iter != nil; iter = iter.Next {
-			carriedObjects = append(carriedObjects, iter.Value.(*ObjectInstance))
+			carriedObjects = append(carriedObjects, iter.Value)
 		}
 
 		if ch.Flags&CHAR_IS_PLAYER != 0 {
@@ -305,7 +305,7 @@ func (game *Game) experienceRecipientsForKill(ch *Character, target *Character, 
 	recipients = append(recipients, ch)
 
 	for iter := ch.Group.Head; iter != nil; iter = iter.Next {
-		gch := iter.Value.(*Character)
+		gch := iter.Value
 		if gch == nil || seen[gch] {
 			continue
 		}
@@ -356,7 +356,7 @@ func (game *Game) Damage(ch *Character, target *Character, display bool, amount 
 	if display && ch != nil {
 		if ch.Room != nil && target.Room != nil && target.Room == ch.Room {
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				character := iter.Value.(*Character)
+				character := iter.Value
 				if character != ch && character != target {
 					character.Send(fmt.Sprintf("{G%s{G %s %s{G for %d damage.{x\r\n",
 						ch.GetShortDescriptionUpper(character),
@@ -405,7 +405,7 @@ func (game *Game) Damage(ch *Character, target *Character, display bool, amount 
 			target.Combat = nil
 
 			for iter := room.Characters.Head; iter != nil; iter = iter.Next {
-				character := iter.Value.(*Character)
+				character := iter.Value
 				character.Send(fmt.Sprintf("{R%s{R has been slain!{x\r\n", target.GetShortDescriptionUpper(character)))
 
 				if character.Fighting != nil && character.Fighting.IsEqual(target) {
@@ -425,7 +425,7 @@ func (game *Game) Damage(ch *Character, target *Character, display bool, amount 
 
 				limbo.AddCharacter(target)
 
-				target.Effects = NewAnyLinkedList()
+				target.Effects = NewLinkedList[*Effect]()
 				target.refreshAffected()
 				target.Health = target.MaxHealth / 8
 				target.Mana = 1
@@ -495,7 +495,7 @@ func do_flee(ch *Character, arguments string) {
 
 		/* Announce player's failed flee attempt to others in the room */
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			rch := iter.Value.(*Character)
+			rch := iter.Value
 
 			if rch != ch {
 				output := fmt.Sprintf("\r\n{R%s{R panics and attempts to flee, but can't get away!{x\r\n", ch.GetShortDescriptionUpper(rch))
@@ -523,7 +523,7 @@ func do_flee(ch *Character, arguments string) {
 
 	/* Announce player's departure to all other players in the current room */
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch != ch {
 			/* If they were fighting this player, then this is a good time to stop their participation in the fight and let it dispose */
@@ -544,7 +544,7 @@ func do_flee(ch *Character, arguments string) {
 
 	/* Announce player's arrival to all other players in the new room */
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch != ch {
 			output := fmt.Sprintf("\r\n{W%s{W arrives from %s.{x\r\n", ch.GetShortDescriptionUpper(rch), ExitName[ReverseDirection[chosenEscape.Direction]])
@@ -595,7 +595,7 @@ func do_kill(ch *Character, arguments string) {
 
 	if ch.Room != nil && target.Room != nil && target.Room == ch.Room {
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			character := iter.Value.(*Character)
+			character := iter.Value
 			if character != ch && character != target {
 				character.Send(fmt.Sprintf("{G%s{G begins attacking %s{G!{x\r\n",
 					ch.GetShortDescriptionUpper(character),

--- a/src/game.go
+++ b/src/game.go
@@ -37,12 +37,12 @@ type Game struct {
 	vm       *goja.Runtime
 	listener net.Listener
 
-	Objects      *LinkedList `json:"objects"`
-	Characters   *LinkedList `json:"characters"`
-	Fights       *LinkedList `json:"fights"`
-	Planes       *LinkedList `json:"planes"`
-	Zones        *LinkedList `json:"zones"`
-	ScriptTimers *LinkedList `json:"scriptTimers"`
+	Objects      *LinkedList[interface{}] `json:"objects"`
+	Characters   *LinkedList[interface{}] `json:"characters"`
+	Fights       *LinkedList[interface{}] `json:"fights"`
+	Planes       *LinkedList[interface{}] `json:"planes"`
+	Zones        *LinkedList[interface{}] `json:"zones"`
+	ScriptTimers *LinkedList[interface{}] `json:"scriptTimers"`
 
 	clients     map[*Client]bool
 	skills      map[uint]*Skill
@@ -51,7 +51,7 @@ type Game struct {
 	mobileShops map[uint]*Shop
 	socials     map[string]*Social
 
-	eventHandlers   map[string]*LinkedList
+	eventHandlers   map[string]*LinkedList[interface{}]
 	Scripts         map[uint]*Script `json:"scripts"`
 	objectScripts   map[uint]*Script
 	districtScripts map[int]*Script
@@ -91,11 +91,11 @@ func NewGame() (*Game, error) {
 	game.clientMessage = make(chan ClientTextMessage)
 	game.planeGenerationCompleted = make(chan int)
 
-	game.Characters = NewLinkedList()
-	game.Fights = NewLinkedList()
-	game.Objects = NewLinkedList()
-	game.ScriptTimers = NewLinkedList()
-	game.Planes = NewLinkedList()
+	game.Characters = NewAnyLinkedList()
+	game.Fights = NewAnyLinkedList()
+	game.Objects = NewAnyLinkedList()
+	game.ScriptTimers = NewAnyLinkedList()
+	game.Planes = NewAnyLinkedList()
 
 	/* Initialize services we'll inject elsewhere through the game instance. */
 	game.db, err = openDatabase()

--- a/src/game.go
+++ b/src/game.go
@@ -37,12 +37,12 @@ type Game struct {
 	vm       *goja.Runtime
 	listener net.Listener
 
-	Objects      *LinkedList[interface{}] `json:"objects"`
-	Characters   *LinkedList[interface{}] `json:"characters"`
-	Fights       *LinkedList[interface{}] `json:"fights"`
-	Planes       *LinkedList[interface{}] `json:"planes"`
-	Zones        *LinkedList[interface{}] `json:"zones"`
-	ScriptTimers *LinkedList[interface{}] `json:"scriptTimers"`
+	Objects      *LinkedList[*ObjectInstance] `json:"objects"`
+	Characters   *LinkedList[*Character]      `json:"characters"`
+	Fights       *LinkedList[*Combat]         `json:"fights"`
+	Planes       *LinkedList[*Plane]          `json:"planes"`
+	Zones        *LinkedList[*Zone]           `json:"zones"`
+	ScriptTimers *LinkedList[*ScriptTimer]    `json:"scriptTimers"`
 
 	clients     map[*Client]bool
 	skills      map[uint]*Skill
@@ -51,7 +51,7 @@ type Game struct {
 	mobileShops map[uint]*Shop
 	socials     map[string]*Social
 
-	eventHandlers   map[string]*LinkedList[interface{}]
+	eventHandlers   map[string]*LinkedList[*EventHandler]
 	Scripts         map[uint]*Script `json:"scripts"`
 	objectScripts   map[uint]*Script
 	districtScripts map[int]*Script
@@ -91,11 +91,11 @@ func NewGame() (*Game, error) {
 	game.clientMessage = make(chan ClientTextMessage)
 	game.planeGenerationCompleted = make(chan int)
 
-	game.Characters = NewAnyLinkedList()
-	game.Fights = NewAnyLinkedList()
-	game.Objects = NewAnyLinkedList()
-	game.ScriptTimers = NewAnyLinkedList()
-	game.Planes = NewAnyLinkedList()
+	game.Characters = NewLinkedList[*Character]()
+	game.Fights = NewLinkedList[*Combat]()
+	game.Objects = NewLinkedList[*ObjectInstance]()
+	game.ScriptTimers = NewLinkedList[*ScriptTimer]()
+	game.Planes = NewLinkedList[*Plane]()
 
 	/* Initialize services we'll inject elsewhere through the game instance. */
 	game.db, err = openDatabase()
@@ -168,7 +168,7 @@ func NewGame() (*Game, error) {
 
 	/* Try to initialize each plane now that potential scripts have been attached */
 	for iter := game.Planes.Head; iter != nil; iter = iter.Next {
-		plane := iter.Value.(*Plane)
+		plane := iter.Value
 
 		log.Printf("Generating %s...\r\n", plane.Name)
 

--- a/src/linked_list.go
+++ b/src/linked_list.go
@@ -9,26 +9,30 @@ package main
 
 import "math/rand"
 
-type LinkedListNode struct {
-	Next  *LinkedListNode `json:"next"`
-	Value interface{}     `json:"value"`
+type LinkedListNode[T comparable] struct {
+	Next  *LinkedListNode[T] `json:"next"`
+	Value T                  `json:"value"`
 }
 
-type LinkedList struct {
-	Head  *LinkedListNode `json:"head"`
-	Count int             `json:"count"`
+type LinkedList[T comparable] struct {
+	Head  *LinkedListNode[T] `json:"head"`
+	Count int                `json:"count"`
 }
 
-func NewLinkedList() *LinkedList {
-	list := &LinkedList{}
+func NewLinkedList[T comparable]() *LinkedList[T] {
+	list := &LinkedList[T]{}
 	list.Head = nil
 	list.Count = 0
 
 	return list
 }
 
-func (list *LinkedList) Remove(value interface{}) bool {
-	var iter *LinkedListNode = list.Head
+func NewAnyLinkedList() *LinkedList[interface{}] {
+	return NewLinkedList[interface{}]()
+}
+
+func (list *LinkedList[T]) Remove(value T) bool {
+	var iter *LinkedListNode[T] = list.Head
 
 	if list.Count == 0 || list.Head == nil {
 		return false
@@ -53,12 +57,12 @@ func (list *LinkedList) Remove(value interface{}) bool {
 	return false
 }
 
-func (list *LinkedList) Insert(value interface{}) {
-	list.Head = &LinkedListNode{Next: list.Head, Value: value}
+func (list *LinkedList[T]) Insert(value T) {
+	list.Head = &LinkedListNode[T]{Next: list.Head, Value: value}
 	list.Count++
 }
 
-func (list *LinkedList) GetRandomNode() *LinkedListNode {
+func (list *LinkedList[T]) GetRandomNode() *LinkedListNode[T] {
 	choice := rand.Intn(list.Count)
 
 	i := 0
@@ -74,7 +78,7 @@ func (list *LinkedList) GetRandomNode() *LinkedListNode {
 }
 
 /* Utility method to concatenate one linked list to another */
-func (list *LinkedList) Concat(other *LinkedList) *LinkedList {
+func (list *LinkedList[T]) Concat(other *LinkedList[T]) *LinkedList[T] {
 	for iter := other.Head; iter != nil; iter = iter.Next {
 		v := iter.Value
 
@@ -84,7 +88,7 @@ func (list *LinkedList) Concat(other *LinkedList) *LinkedList {
 	return list
 }
 
-func (list *LinkedList) Contains(value interface{}) bool {
+func (list *LinkedList[T]) Contains(value T) bool {
 	for iter := list.Head; iter != nil; iter = iter.Next {
 		v := iter.Value
 
@@ -96,8 +100,8 @@ func (list *LinkedList) Contains(value interface{}) bool {
 	return false
 }
 
-func (list *LinkedList) Values() []interface{} {
-	var values []interface{} = make([]interface{}, 0)
+func (list *LinkedList[T]) Values() []T {
+	var values []T = make([]T, 0)
 
 	for iter := list.Head; iter != nil; iter = iter.Next {
 		values = append(values, iter.Value)

--- a/src/linked_list_test.go
+++ b/src/linked_list_test.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021 James Skarzinskas.
+ * All rights reserved.
+ * See LICENSE.txt in project root for license information.
+ * Authors:
+ *     James Skarzinskas <james@jskarzin.org>
+ */
+package main
+
+import "testing"
+
+func TestLinkedListInsert(t *testing.T) {
+	list := NewLinkedList[int]()
+
+	list.Insert(1)
+	list.Insert(2)
+
+	if list.Count != 2 {
+		t.Fatalf("list count = %d, want 2", list.Count)
+	}
+
+	if list.Head == nil || list.Head.Value != 2 {
+		t.Fatalf("list head = %v, want 2", list.Head)
+	}
+
+	if list.Head.Next == nil || list.Head.Next.Value != 1 {
+		t.Fatalf("second list value = %v, want 1", list.Head.Next)
+	}
+}
+
+func TestLinkedListRemoveHead(t *testing.T) {
+	list := NewLinkedList[int]()
+	list.Insert(1)
+	list.Insert(2)
+
+	if !list.Remove(2) {
+		t.Fatal("Remove(2) = false, want true")
+	}
+
+	if list.Count != 1 {
+		t.Fatalf("list count = %d, want 1", list.Count)
+	}
+
+	if list.Head == nil || list.Head.Value != 1 {
+		t.Fatalf("list head = %v, want 1", list.Head)
+	}
+}
+
+func TestLinkedListRemoveMiddle(t *testing.T) {
+	list := NewLinkedList[int]()
+	list.Insert(1)
+	list.Insert(2)
+	list.Insert(3)
+
+	if !list.Remove(2) {
+		t.Fatal("Remove(2) = false, want true")
+	}
+
+	if list.Count != 2 {
+		t.Fatalf("list count = %d, want 2", list.Count)
+	}
+
+	if list.Head == nil || list.Head.Value != 3 {
+		t.Fatalf("list head = %v, want 3", list.Head)
+	}
+
+	if list.Head.Next == nil || list.Head.Next.Value != 1 {
+		t.Fatalf("second list value = %v, want 1", list.Head.Next)
+	}
+}
+
+func TestLinkedListRemoveMissing(t *testing.T) {
+	list := NewLinkedList[int]()
+	list.Insert(1)
+	list.Insert(2)
+
+	if list.Remove(3) {
+		t.Fatal("Remove(3) = true, want false")
+	}
+
+	if list.Count != 2 {
+		t.Fatalf("list count = %d, want 2", list.Count)
+	}
+}
+
+func TestLinkedListContains(t *testing.T) {
+	list := NewLinkedList[int]()
+	list.Insert(1)
+	list.Insert(2)
+
+	if !list.Contains(1) {
+		t.Fatal("Contains(1) = false, want true")
+	}
+
+	if list.Contains(3) {
+		t.Fatal("Contains(3) = true, want false")
+	}
+}
+
+func TestLinkedListConcat(t *testing.T) {
+	list := NewLinkedList[int]()
+	other := NewLinkedList[int]()
+
+	list.Insert(1)
+	other.Insert(2)
+	other.Insert(3)
+
+	if got := list.Concat(other); got != list {
+		t.Fatal("Concat returned a different list")
+	}
+
+	values := list.Values()
+	expected := []int{2, 3, 1}
+
+	if len(values) != len(expected) {
+		t.Fatalf("len(Values()) = %d, want %d", len(values), len(expected))
+	}
+
+	for i, value := range values {
+		if value != expected[i] {
+			t.Fatalf("Values()[%d] = %d, want %d", i, value, expected[i])
+		}
+	}
+}
+
+func TestLinkedListValues(t *testing.T) {
+	list := NewLinkedList[int]()
+	list.Insert(1)
+	list.Insert(2)
+
+	values := list.Values()
+	expected := []int{2, 1}
+
+	if len(values) != len(expected) {
+		t.Fatalf("len(Values()) = %d, want %d", len(values), len(expected))
+	}
+
+	for i, value := range values {
+		if value != expected[i] {
+			t.Fatalf("Values()[%d] = %d, want %d", i, value, expected[i])
+		}
+	}
+}
+
+func TestLinkedListGetRandomNode(t *testing.T) {
+	list := NewLinkedList[int]()
+	list.Insert(1)
+
+	node := list.GetRandomNode()
+	if node == nil {
+		t.Fatal("GetRandomNode() = nil, want node")
+	}
+
+	if node.Value != 1 {
+		t.Fatalf("GetRandomNode().Value = %d, want 1", node.Value)
+	}
+}

--- a/src/magic.go
+++ b/src/magic.go
@@ -30,7 +30,7 @@ func (ch *Character) onCastingUpdate() {
 		ch.Send("\r\n{WYou lose your concentration and your magic spell fizzles out.{x\r\n")
 		if ch.Room != nil {
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if !rch.IsEqual(ch) {
 					rch.Send(fmt.Sprintf("\r\n{W%s{W seems to lose their concentration.{W{x\r\n", ch.GetShortDescriptionUpper(rch)))
@@ -47,7 +47,7 @@ func (ch *Character) onCastingUpdate() {
 
 		if ch.Room != nil {
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if !rch.IsEqual(ch) {
 					rch.Send(fmt.Sprintf("\r\n{W%s{W finishes casting their magic spell.{W{x\r\n", ch.GetShortDescriptionUpper(rch)))
@@ -131,7 +131,7 @@ func do_cast(ch *Character, arguments string) {
 
 	ch.Send("{WYou start uttering the words of the spell...{x\r\n")
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 		if character != ch {
 			character.Send(fmt.Sprintf("\r\n{W%s{W begins casting a spell...{x\r\n", ch.GetShortDescriptionUpper(character)))
 		}

--- a/src/maze.go
+++ b/src/maze.go
@@ -86,8 +86,8 @@ func (grid *MazeGrid) cellAt(x int, y int) *MazeCell {
 	return grid.Grid[x][y]
 }
 
-func (cell *MazeCell) getAdjacentCells(wall bool, distance int, ordinals bool) *LinkedList {
-	list := NewLinkedList()
+func (cell *MazeCell) getAdjacentCells(wall bool, distance int, ordinals bool) *LinkedList[interface{}] {
+	list := NewAnyLinkedList()
 
 	if cell == nil || cell.Grid == nil {
 		return list
@@ -217,8 +217,8 @@ func (maze *MazeGrid) createRoom(x int, y int) *Room {
 	room.Name = "In the Underground"
 	room.Description = "You are deep within the dark dungeons of development."
 	room.Exit = make(map[uint]*Exit)
-	room.Characters = NewLinkedList()
-	room.Objects = NewLinkedList()
+	room.Characters = NewAnyLinkedList()
+	room.Objects = NewAnyLinkedList()
 
 	maze.Grid[x][y].Room = room
 	return room

--- a/src/maze.go
+++ b/src/maze.go
@@ -217,8 +217,8 @@ func (maze *MazeGrid) createRoom(x int, y int) *Room {
 	room.Name = "In the Underground"
 	room.Description = "You are deep within the dark dungeons of development."
 	room.Exit = make(map[uint]*Exit)
-	room.Characters = NewAnyLinkedList()
-	room.Objects = NewAnyLinkedList()
+	room.Characters = NewLinkedList[*Character]()
+	room.Objects = NewLinkedList[*ObjectInstance]()
 
 	maze.Grid[x][y].Room = room
 	return room

--- a/src/maze.go
+++ b/src/maze.go
@@ -86,8 +86,8 @@ func (grid *MazeGrid) cellAt(x int, y int) *MazeCell {
 	return grid.Grid[x][y]
 }
 
-func (cell *MazeCell) getAdjacentCells(wall bool, distance int, ordinals bool) *LinkedList[interface{}] {
-	list := NewAnyLinkedList()
+func (cell *MazeCell) getAdjacentCells(wall bool, distance int, ordinals bool) *LinkedList[*MazeCell] {
+	list := NewLinkedList[*MazeCell]()
 
 	if cell == nil || cell.Grid == nil {
 		return list
@@ -142,7 +142,7 @@ func (cell *MazeCell) setAdjacentCellsTerrainType(wall bool, distance int, terra
 	cells := cell.getAdjacentCells(wall, distance, true)
 
 	for iter := cells.Head; iter != nil; iter = iter.Next {
-		cell := iter.Value.(*MazeCell)
+		cell := iter.Value
 
 		if cell.Wall == wall {
 			cell.Terrain = terrain
@@ -171,11 +171,11 @@ func (maze *MazeGrid) generatePrimMaze() {
 			break
 		}
 
-		f := frontiers.GetRandomNode().Value.(*MazeCell)
+		f := frontiers.GetRandomNode().Value
 		neighbours := f.getAdjacentCells(false, 2, false)
 
 		if neighbours.Count > 0 {
-			neighbour := neighbours.GetRandomNode().Value.(*MazeCell)
+			neighbour := neighbours.GetRandomNode().Value
 
 			passageX := (neighbour.X + f.X) / 2
 			passageY := (neighbour.Y + f.Y) / 2

--- a/src/nanny.go
+++ b/src/nanny.go
@@ -214,7 +214,7 @@ func (game *Game) nanny(client *Client, message string) {
 		index := 0
 
 		for iter := Races.Head; iter != nil; iter = iter.Next {
-			race := iter.Value.(*Race)
+			race := iter.Value
 
 			if !race.Playable {
 				continue
@@ -251,7 +251,7 @@ func (game *Game) nanny(client *Client, message string) {
 			index := 0
 
 			for iter := Races.Head; iter != nil; iter = iter.Next {
-				race := iter.Value.(*Race)
+				race := iter.Value
 
 				if !race.Playable {
 					continue
@@ -277,7 +277,7 @@ func (game *Game) nanny(client *Client, message string) {
 		index := 0
 
 		for iter := Jobs.Head; iter != nil; iter = iter.Next {
-			job := iter.Value.(*Job)
+			job := iter.Value
 
 			if !job.Playable {
 				continue
@@ -314,7 +314,7 @@ func (game *Game) nanny(client *Client, message string) {
 			index := 0
 
 			for iter := Jobs.Head; iter != nil; iter = iter.Next {
-				job := iter.Value.(*Job)
+				job := iter.Value
 
 				if !job.Playable {
 					continue

--- a/src/object.go
+++ b/src/object.go
@@ -36,11 +36,11 @@ type Object struct {
 }
 
 type ObjectInstance struct {
-	Game      *Game           `json:"game"`
-	Contents  *LinkedList     `json:"contents"`
-	Inside    *ObjectInstance `json:"inside"`
-	InRoom    *Room           `json:"inRoom"`
-	CarriedBy *Character      `json:"carriedBy"`
+	Game      *Game                    `json:"game"`
+	Contents  *LinkedList[interface{}] `json:"contents"`
+	Inside    *ObjectInstance          `json:"inside"`
+	InRoom    *Room                    `json:"inRoom"`
+	CarriedBy *Character               `json:"carriedBy"`
 
 	Id       uint   `json:"id"`
 	ParentId uint   `json:"parentId"`
@@ -256,7 +256,7 @@ func (game *Game) objectInstanceFromIndex(obj *Object) *ObjectInstance {
 	objectInstance := &ObjectInstance{
 		Game:             game,
 		ParentId:         obj.Id,
-		Contents:         NewLinkedList(),
+		Contents:         NewAnyLinkedList(),
 		Description:      obj.Description,
 		ShortDescription: obj.ShortDescription,
 		LongDescription:  obj.LongDescription,
@@ -810,9 +810,9 @@ func (obj *ObjectInstance) Finalize(container *ObjectInstance) error {
 	return nil
 }
 
-func (obj *ObjectInstance) ensureContents() *LinkedList {
+func (obj *ObjectInstance) ensureContents() *LinkedList[interface{}] {
 	if obj.Contents == nil {
-		obj.Contents = NewLinkedList()
+		obj.Contents = NewAnyLinkedList()
 	}
 
 	return obj.Contents
@@ -835,7 +835,7 @@ func (container *ObjectInstance) removeObject(obj *ObjectInstance) {
 	obj.InRoom = nil
 }
 
-func (ch *Character) showObjectList(objects *LinkedList) {
+func (ch *Character) showObjectList(objects *LinkedList[interface{}]) {
 	var output strings.Builder
 
 	if objects == nil || objects.Count < 1 {

--- a/src/object.go
+++ b/src/object.go
@@ -36,11 +36,11 @@ type Object struct {
 }
 
 type ObjectInstance struct {
-	Game      *Game                    `json:"game"`
-	Contents  *LinkedList[interface{}] `json:"contents"`
-	Inside    *ObjectInstance          `json:"inside"`
-	InRoom    *Room                    `json:"inRoom"`
-	CarriedBy *Character               `json:"carriedBy"`
+	Game      *Game                        `json:"game"`
+	Contents  *LinkedList[*ObjectInstance] `json:"contents"`
+	Inside    *ObjectInstance              `json:"inside"`
+	InRoom    *Room                        `json:"inRoom"`
+	CarriedBy *Character                   `json:"carriedBy"`
 
 	Id       uint   `json:"id"`
 	ParentId uint   `json:"parentId"`
@@ -256,7 +256,7 @@ func (game *Game) objectInstanceFromIndex(obj *Object) *ObjectInstance {
 	objectInstance := &ObjectInstance{
 		Game:             game,
 		ParentId:         obj.Id,
-		Contents:         NewAnyLinkedList(),
+		Contents:         NewLinkedList[*ObjectInstance](),
 		Description:      obj.Description,
 		ShortDescription: obj.ShortDescription,
 		LongDescription:  obj.LongDescription,
@@ -424,7 +424,7 @@ func (obj *ObjectInstance) CountFurnitureUsers() int {
 
 	count := 0
 	for iter := obj.InRoom.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 		if rch.Furniture == obj {
 			count++
 		}
@@ -596,7 +596,7 @@ func (obj *ObjectInstance) GetContentsWeight() float64 {
 
 	var total float64
 	for iter := obj.Contents.Head; iter != nil; iter = iter.Next {
-		containedObject := iter.Value.(*ObjectInstance)
+		containedObject := iter.Value
 		total += containedObject.GetTotalWeight()
 	}
 
@@ -653,7 +653,7 @@ func (obj *ObjectInstance) reifyInContainerTx(ctx context.Context, tx *sql.Tx, c
 
 	if obj.Contents != nil && obj.Contents.Count > 0 {
 		for iter := obj.Contents.Head; iter != nil; iter = iter.Next {
-			containedObject := iter.Value.(*ObjectInstance)
+			containedObject := iter.Value
 
 			containedReified, err := containedObject.reifyInContainerTx(ctx, tx, obj)
 			reified = append(reified, containedReified...)
@@ -678,7 +678,7 @@ func (obj *ObjectInstance) objectInstanceIDs() []uint {
 
 	if obj.Contents != nil {
 		for iter := obj.Contents.Head; iter != nil; iter = iter.Next {
-			containedObject := iter.Value.(*ObjectInstance)
+			containedObject := iter.Value
 			ids = append(ids, containedObject.objectInstanceIDs()...)
 		}
 	}
@@ -695,7 +695,7 @@ func (obj *ObjectInstance) resetObjectInstanceIDs() {
 
 	if obj.Contents != nil {
 		for iter := obj.Contents.Head; iter != nil; iter = iter.Next {
-			containedObject := iter.Value.(*ObjectInstance)
+			containedObject := iter.Value
 			containedObject.resetObjectInstanceIDs()
 		}
 	}
@@ -810,9 +810,9 @@ func (obj *ObjectInstance) Finalize(container *ObjectInstance) error {
 	return nil
 }
 
-func (obj *ObjectInstance) ensureContents() *LinkedList[interface{}] {
+func (obj *ObjectInstance) ensureContents() *LinkedList[*ObjectInstance] {
 	if obj.Contents == nil {
-		obj.Contents = NewAnyLinkedList()
+		obj.Contents = NewLinkedList[*ObjectInstance]()
 	}
 
 	return obj.Contents
@@ -835,7 +835,7 @@ func (container *ObjectInstance) removeObject(obj *ObjectInstance) {
 	obj.InRoom = nil
 }
 
-func (ch *Character) showObjectList(objects *LinkedList[interface{}]) {
+func (ch *Character) showObjectList(objects *LinkedList[*ObjectInstance]) {
 	var output strings.Builder
 
 	if objects == nil || objects.Count < 1 {
@@ -843,7 +843,7 @@ func (ch *Character) showObjectList(objects *LinkedList[interface{}]) {
 	}
 
 	for iter := objects.Head; iter != nil; iter = iter.Next {
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		output.WriteString(fmt.Sprintf("  %s\r\n", obj.GetShortDescriptionUpper(ch)))
 	}

--- a/src/plane.go
+++ b/src/plane.go
@@ -678,7 +678,7 @@ func (plane *Plane) GetTerrainRect(x int, y int, z int, w int, h int) [][]int {
 
 func (game *Game) FindPlaneByName(name string) *Plane {
 	for iter := game.Planes.Head; iter != nil; iter = iter.Next {
-		plane := iter.Value.(*Plane)
+		plane := iter.Value
 
 		if plane.Name == name {
 			return plane
@@ -690,7 +690,7 @@ func (game *Game) FindPlaneByName(name string) *Plane {
 
 func (game *Game) FindPlaneByID(id int) *Plane {
 	for iter := game.Planes.Head; iter != nil; iter = iter.Next {
-		plane := iter.Value.(*Plane)
+		plane := iter.Value
 
 		if plane.Id == id {
 			return plane
@@ -737,7 +737,7 @@ func (game *Game) LoadPlanes() error {
 		}
 
 		for iter := game.Zones.Head; iter != nil; iter = iter.Next {
-			zone := iter.Value.(*Zone)
+			zone := iter.Value
 
 			if zone.Id == zoneId {
 				plane.Zone = zone
@@ -841,7 +841,7 @@ func (game *Game) LoadDistricts() error {
 
 func (game *Game) FindDistrictByID(id int) *District {
 	for planeIter := game.Planes.Head; planeIter != nil; planeIter = planeIter.Next {
-		plane := planeIter.Value.(*Plane)
+		plane := planeIter.Value
 
 		if plane.Map == nil || len(plane.Map.Layers) == 0 {
 			continue

--- a/src/plane.go
+++ b/src/plane.go
@@ -77,10 +77,10 @@ type Atlas struct {
 	Plane *Plane `json:"plane"`
 
 	// TODO: portals, scripts
-	Characters map[int]*LinkedList[interface{}] `json:"characters"`
-	Objects    map[int]*LinkedList[interface{}] `json:"objects"`
-	Rooms      map[int]*LinkedList[interface{}] `json:"rooms"`
-	Exits      map[int]map[uint]*Exit           `json:"exits"`
+	Characters map[int]*LinkedList[*Character]      `json:"characters"`
+	Objects    map[int]*LinkedList[*ObjectInstance] `json:"objects"`
+	Rooms      map[int]*LinkedList[interface{}]     `json:"rooms"`
+	Exits      map[int]map[uint]*Exit               `json:"exits"`
 
 	CharacterTree *QuadTree `json:"characterTree"`
 	ObjectTree    *QuadTree `json:"objectTree"`
@@ -130,8 +130,8 @@ func (plane *Plane) SupportsPersistentCoordinates() bool {
 func (plane *Plane) NewAtlas() *Atlas {
 	return &Atlas{
 		Plane:      plane,
-		Characters: make(map[int]*LinkedList[interface{}]),
-		Objects:    make(map[int]*LinkedList[interface{}]),
+		Characters: make(map[int]*LinkedList[*Character]),
+		Objects:    make(map[int]*LinkedList[*ObjectInstance]),
 		Exits:      make(map[int]map[uint]*Exit),
 
 		CharacterTree: NewQuadTree(float64(plane.Width), float64(plane.Height)),
@@ -565,7 +565,7 @@ func (plane *Plane) MaterializeRoom(x int, y int, z int, src bool) *Room {
 
 	room.Characters, ok = plane.Map.Layers[z].Atlas.Characters[atlasKey]
 	if !ok {
-		list := NewAnyLinkedList()
+		list := NewLinkedList[*Character]()
 
 		plane.Map.Layers[z].Atlas.Characters[atlasKey] = list
 		room.Characters = list
@@ -574,7 +574,7 @@ func (plane *Plane) MaterializeRoom(x int, y int, z int, src bool) *Room {
 	ok = false
 	room.Objects, ok = plane.Map.Layers[z].Atlas.Objects[atlasKey]
 	if !ok {
-		list := NewAnyLinkedList()
+		list := NewLinkedList[*ObjectInstance]()
 
 		plane.Map.Layers[z].Atlas.Objects[atlasKey] = list
 		room.Objects = list

--- a/src/plane.go
+++ b/src/plane.go
@@ -32,9 +32,9 @@ type Plane struct {
 	SourceType string   `json:"sourceType"`
 	Scripts    *Script  `json:"scripts"`
 
-	Map     *Map        `json:"map"`
-	Maze    *MazeGrid   `json:"maze"`
-	Portals *LinkedList `json:"portals"`
+	Map     *Map                     `json:"map"`
+	Maze    *MazeGrid                `json:"maze"`
+	Portals *LinkedList[interface{}] `json:"portals"`
 }
 
 type District struct {
@@ -54,8 +54,8 @@ type PlaneObserver struct {
 }
 
 type MapGrid struct {
-	Observers []*PlaneObserver `json:"observers"`
-	Districts *LinkedList      `json:"districts"`
+	Observers []*PlaneObserver         `json:"observers"`
+	Districts *LinkedList[interface{}] `json:"districts"`
 
 	Terrain [][]int `json:"terrain"`
 	Atlas   *Atlas  `json:"atlas"`
@@ -77,10 +77,10 @@ type Atlas struct {
 	Plane *Plane `json:"plane"`
 
 	// TODO: portals, scripts
-	Characters map[int]*LinkedList    `json:"characters"`
-	Objects    map[int]*LinkedList    `json:"objects"`
-	Rooms      map[int]*LinkedList    `json:"rooms"`
-	Exits      map[int]map[uint]*Exit `json:"exits"`
+	Characters map[int]*LinkedList[interface{}] `json:"characters"`
+	Objects    map[int]*LinkedList[interface{}] `json:"objects"`
+	Rooms      map[int]*LinkedList[interface{}] `json:"rooms"`
+	Exits      map[int]map[uint]*Exit           `json:"exits"`
 
 	CharacterTree *QuadTree `json:"characterTree"`
 	ObjectTree    *QuadTree `json:"objectTree"`
@@ -130,8 +130,8 @@ func (plane *Plane) SupportsPersistentCoordinates() bool {
 func (plane *Plane) NewAtlas() *Atlas {
 	return &Atlas{
 		Plane:      plane,
-		Characters: make(map[int]*LinkedList),
-		Objects:    make(map[int]*LinkedList),
+		Characters: make(map[int]*LinkedList[interface{}]),
+		Objects:    make(map[int]*LinkedList[interface{}]),
 		Exits:      make(map[int]map[uint]*Exit),
 
 		CharacterTree: NewQuadTree(float64(plane.Width), float64(plane.Height)),
@@ -158,7 +158,7 @@ func (plane *Plane) containsCoordinates(x int, y int, z int) bool {
 }
 
 func (plane *Plane) newMapGrid() *MapGrid {
-	grid := &MapGrid{Atlas: plane.NewAtlas(), Districts: NewLinkedList()}
+	grid := &MapGrid{Atlas: plane.NewAtlas(), Districts: NewAnyLinkedList()}
 	grid.Terrain = make([][]int, plane.Height)
 
 	for y := 0; y < plane.Height; y++ {
@@ -261,7 +261,7 @@ func (plane *Plane) districtLayer(z int) (*MapGrid, bool) {
 	}
 
 	if layer.Districts == nil {
-		layer.Districts = NewLinkedList()
+		layer.Districts = NewAnyLinkedList()
 	}
 
 	return layer, true
@@ -565,7 +565,7 @@ func (plane *Plane) MaterializeRoom(x int, y int, z int, src bool) *Room {
 
 	room.Characters, ok = plane.Map.Layers[z].Atlas.Characters[atlasKey]
 	if !ok {
-		list := NewLinkedList()
+		list := NewAnyLinkedList()
 
 		plane.Map.Layers[z].Atlas.Characters[atlasKey] = list
 		room.Characters = list
@@ -574,7 +574,7 @@ func (plane *Plane) MaterializeRoom(x int, y int, z int, src bool) *Room {
 	ok = false
 	room.Objects, ok = plane.Map.Layers[z].Atlas.Objects[atlasKey]
 	if !ok {
-		list := NewLinkedList()
+		list := NewAnyLinkedList()
 
 		plane.Map.Layers[z].Atlas.Objects[atlasKey] = list
 		room.Objects = list
@@ -725,7 +725,7 @@ func (game *Game) LoadPlanes() error {
 
 	for rows.Next() {
 		plane := &Plane{Game: game}
-		plane.Portals = NewLinkedList()
+		plane.Portals = NewAnyLinkedList()
 		plane.Flags = 0
 
 		var zoneId int = 0

--- a/src/plane.go
+++ b/src/plane.go
@@ -32,9 +32,9 @@ type Plane struct {
 	SourceType string   `json:"sourceType"`
 	Scripts    *Script  `json:"scripts"`
 
-	Map     *Map                     `json:"map"`
-	Maze    *MazeGrid                `json:"maze"`
-	Portals *LinkedList[interface{}] `json:"portals"`
+	Map     *Map                 `json:"map"`
+	Maze    *MazeGrid            `json:"maze"`
+	Portals *LinkedList[*Portal] `json:"portals"`
 }
 
 type District struct {
@@ -54,8 +54,8 @@ type PlaneObserver struct {
 }
 
 type MapGrid struct {
-	Observers []*PlaneObserver         `json:"observers"`
-	Districts *LinkedList[interface{}] `json:"districts"`
+	Observers []*PlaneObserver       `json:"observers"`
+	Districts *LinkedList[*District] `json:"districts"`
 
 	Terrain [][]int `json:"terrain"`
 	Atlas   *Atlas  `json:"atlas"`
@@ -79,7 +79,7 @@ type Atlas struct {
 	// TODO: portals, scripts
 	Characters map[int]*LinkedList[*Character]      `json:"characters"`
 	Objects    map[int]*LinkedList[*ObjectInstance] `json:"objects"`
-	Rooms      map[int]*LinkedList[interface{}]     `json:"rooms"`
+	Rooms      map[int]*LinkedList[*Room]           `json:"rooms"`
 	Exits      map[int]map[uint]*Exit               `json:"exits"`
 
 	CharacterTree *QuadTree `json:"characterTree"`
@@ -132,6 +132,7 @@ func (plane *Plane) NewAtlas() *Atlas {
 		Plane:      plane,
 		Characters: make(map[int]*LinkedList[*Character]),
 		Objects:    make(map[int]*LinkedList[*ObjectInstance]),
+		Rooms:      make(map[int]*LinkedList[*Room]),
 		Exits:      make(map[int]map[uint]*Exit),
 
 		CharacterTree: NewQuadTree(float64(plane.Width), float64(plane.Height)),
@@ -158,7 +159,7 @@ func (plane *Plane) containsCoordinates(x int, y int, z int) bool {
 }
 
 func (plane *Plane) newMapGrid() *MapGrid {
-	grid := &MapGrid{Atlas: plane.NewAtlas(), Districts: NewAnyLinkedList()}
+	grid := &MapGrid{Atlas: plane.NewAtlas(), Districts: NewLinkedList[*District]()}
 	grid.Terrain = make([][]int, plane.Height)
 
 	for y := 0; y < plane.Height; y++ {
@@ -240,7 +241,7 @@ func (obs *PlaneObserver) Dispose() {
 
 func (layer *MapGrid) FindDistrict(x int, y int) *District {
 	for iter := layer.Districts.Head; iter != nil; iter = iter.Next {
-		d := iter.Value.(*District)
+		d := iter.Value
 
 		if d.Rect.Contains(float64(x), float64(y)) {
 			return d
@@ -261,7 +262,7 @@ func (plane *Plane) districtLayer(z int) (*MapGrid, bool) {
 	}
 
 	if layer.Districts == nil {
-		layer.Districts = NewAnyLinkedList()
+		layer.Districts = NewLinkedList[*District]()
 	}
 
 	return layer, true
@@ -725,7 +726,7 @@ func (game *Game) LoadPlanes() error {
 
 	for rows.Next() {
 		plane := &Plane{Game: game}
-		plane.Portals = NewAnyLinkedList()
+		plane.Portals = NewLinkedList[*Portal]()
 		plane.Flags = 0
 
 		var zoneId int = 0
@@ -813,7 +814,7 @@ func (game *Game) LoadDistricts() error {
 		collides := false
 
 		for iter := layer.Districts.Head; iter != nil; iter = iter.Next {
-			d := iter.Value.(*District)
+			d := iter.Value
 
 			if d.Rect.CollidesRect(district.Rect) {
 				log.Printf("District %d collides with an existing district, ignoring.\r\n", district.Id)
@@ -853,7 +854,7 @@ func (game *Game) FindDistrictByID(id int) *District {
 			}
 
 			for districtIter := layer.Districts.Head; districtIter != nil; districtIter = districtIter.Next {
-				district := districtIter.Value.(*District)
+				district := districtIter.Value
 
 				if district.Id == id {
 					return district

--- a/src/quad_tree.go
+++ b/src/quad_tree.go
@@ -18,10 +18,10 @@ type QuadTree struct {
 	Southwest *QuadTree `json:"sw"`
 	Southeast *QuadTree `json:"se"`
 
-	Boundary *Rect       `json:"boundary"`
-	Nodes    *LinkedList `json:"data"`
-	Capacity int         `json:"capacity"`
-	Parent   *QuadTree   `json:"parent"`
+	Boundary *Rect                    `json:"boundary"`
+	Nodes    *LinkedList[interface{}] `json:"data"`
+	Capacity int                      `json:"capacity"`
+	Parent   *QuadTree                `json:"parent"`
 }
 
 const QuadTreeNodeMaxElements = 4
@@ -160,7 +160,7 @@ func (qt *QuadTree) Collapse() bool {
 		qt.Southwest = nil
 		qt.Southeast = nil
 
-		qt.Nodes = NewLinkedList()
+		qt.Nodes = NewAnyLinkedList()
 
 		for _, p := range results {
 			qt.Nodes.Insert(p)
@@ -244,7 +244,7 @@ func (qt *QuadTree) QueryRect(r *Rect) []*Point {
 func NewQuadTree(width float64, height float64) *QuadTree {
 	qt := &QuadTree{
 		Capacity: QuadTreeNodeMaxElements,
-		Nodes:    NewLinkedList(),
+		Nodes:    NewAnyLinkedList(),
 		Boundary: &Rect{X: 0, Y: 0, W: width, H: height},
 		Parent:   nil,
 	}

--- a/src/quad_tree.go
+++ b/src/quad_tree.go
@@ -18,10 +18,10 @@ type QuadTree struct {
 	Southwest *QuadTree `json:"sw"`
 	Southeast *QuadTree `json:"se"`
 
-	Boundary *Rect                    `json:"boundary"`
-	Nodes    *LinkedList[interface{}] `json:"data"`
-	Capacity int                      `json:"capacity"`
-	Parent   *QuadTree                `json:"parent"`
+	Boundary *Rect               `json:"boundary"`
+	Nodes    *LinkedList[*Point] `json:"data"`
+	Capacity int                 `json:"capacity"`
+	Parent   *QuadTree           `json:"parent"`
 }
 
 const QuadTreeNodeMaxElements = 4
@@ -67,7 +67,7 @@ func (qt *QuadTree) Subdivide() bool {
 
 	// Repartition the nodes at this level to the appropriate child quad
 	for iter := qt.Nodes.Head; iter != nil; iter = iter.Next {
-		point := iter.Value.(*Point)
+		point := iter.Value
 
 		if qt.Northwest.Boundary.ContainsPoint(point) {
 			qt.Northwest.Nodes.Insert(point)
@@ -160,7 +160,7 @@ func (qt *QuadTree) Collapse() bool {
 		qt.Southwest = nil
 		qt.Southeast = nil
 
-		qt.Nodes = NewAnyLinkedList()
+		qt.Nodes = NewLinkedList[*Point]()
 
 		for _, p := range results {
 			qt.Nodes.Insert(p)
@@ -219,7 +219,7 @@ func (qt *QuadTree) QueryRect(r *Rect) []*Point {
 	}
 
 	for iter := qt.Nodes.Head; iter != nil; iter = iter.Next {
-		p := iter.Value.(*Point)
+		p := iter.Value
 
 		if r.ContainsPoint(p) {
 			results = append(results, p)
@@ -244,7 +244,7 @@ func (qt *QuadTree) QueryRect(r *Rect) []*Point {
 func NewQuadTree(width float64, height float64) *QuadTree {
 	qt := &QuadTree{
 		Capacity: QuadTreeNodeMaxElements,
-		Nodes:    NewAnyLinkedList(),
+		Nodes:    NewLinkedList[*Point](),
 		Boundary: &Rect{X: 0, Y: 0, W: width, H: height},
 		Parent:   nil,
 	}

--- a/src/quad_tree_test.go
+++ b/src/quad_tree_test.go
@@ -44,7 +44,7 @@ func TestQuadTreeInsert(t *testing.T) {
 		t.Errorf("Root quadtree boundary contained %d points, expected %d.", len(results), len(examplePoints))
 	}
 
-	matches := make([]interface{}, 0)
+	matches := make([]*Point, 0)
 	for _, p := range examplePoints {
 		for _, match := range results {
 			if match == p {

--- a/src/room.go
+++ b/src/room.go
@@ -61,9 +61,9 @@ type Room struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 
-	Objects    *LinkedList `json:"objects"`
-	Resets     *LinkedList `json:"resets"`
-	Characters *LinkedList `json:"characters"`
+	Objects    *LinkedList[interface{}] `json:"objects"`
+	Resets     *LinkedList[interface{}] `json:"resets"`
+	Characters *LinkedList[interface{}] `json:"characters"`
 
 	Exit map[uint]*Exit `json:"exit"`
 }
@@ -322,9 +322,9 @@ func (game *Game) LoadRoomIndex(index uint) (*Room, error) {
 	var zoneId int
 
 	room = &Room{Game: game}
-	room.Resets = NewLinkedList()
-	room.Objects = NewLinkedList()
-	room.Characters = NewLinkedList()
+	room.Resets = NewAnyLinkedList()
+	room.Objects = NewAnyLinkedList()
+	room.Characters = NewAnyLinkedList()
 	room.Exit = make(map[uint]*Exit)
 	err := row.Scan(&room.Id, &zoneId, &room.Name, &room.Description, &room.Flags)
 

--- a/src/room.go
+++ b/src/room.go
@@ -61,9 +61,9 @@ type Room struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 
-	Objects    *LinkedList[interface{}] `json:"objects"`
-	Resets     *LinkedList[interface{}] `json:"resets"`
-	Characters *LinkedList[interface{}] `json:"characters"`
+	Objects    *LinkedList[*ObjectInstance] `json:"objects"`
+	Resets     *LinkedList[*Reset]          `json:"resets"`
+	Characters *LinkedList[*Character]      `json:"characters"`
 
 	Exit map[uint]*Exit `json:"exit"`
 }
@@ -92,7 +92,7 @@ func (room *Room) clearFurnitureUsers(obj *ObjectInstance) {
 	}
 
 	for iter := room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 		if rch.Furniture == obj {
 			rch.Furniture = nil
 		}
@@ -115,7 +115,7 @@ func (room *Room) ActiveLightSourcePresent() bool {
 	}
 
 	for iter := room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch.HasEquippedLightSource() {
 			return true
@@ -282,7 +282,7 @@ func (room *Room) listOtherRoomCharactersToCharacter(ch *Character) {
 	var output strings.Builder
 
 	for iter := room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch != ch {
 			output.WriteString(fmt.Sprintf("{G%s{x\r\n", rch.getLongDescription(ch)))
@@ -322,9 +322,9 @@ func (game *Game) LoadRoomIndex(index uint) (*Room, error) {
 	var zoneId int
 
 	room = &Room{Game: game}
-	room.Resets = NewAnyLinkedList()
-	room.Objects = NewAnyLinkedList()
-	room.Characters = NewAnyLinkedList()
+	room.Resets = NewLinkedList[*Reset]()
+	room.Objects = NewLinkedList[*ObjectInstance]()
+	room.Characters = NewLinkedList[*Character]()
 	room.Exit = make(map[uint]*Exit)
 	err := row.Scan(&room.Id, &zoneId, &room.Name, &room.Description, &room.Flags)
 
@@ -448,7 +448,7 @@ func (room *Room) Broadcast(message string, filter goja.Callable) {
 	for iter := room.Characters.Head; iter != nil; iter = iter.Next {
 		var result bool = false
 
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if filter != nil {
 			val, err := filter(room.Game.vm.ToValue(rch))

--- a/src/room.go
+++ b/src/room.go
@@ -337,7 +337,7 @@ func (game *Game) LoadRoomIndex(index uint) (*Room, error) {
 	}
 
 	for iter := game.Zones.Head; iter != nil; iter = iter.Next {
-		zone := iter.Value.(*Zone)
+		zone := iter.Value
 
 		if zone.Id == zoneId {
 			room.Zone = zone

--- a/src/scripting.go
+++ b/src/scripting.go
@@ -624,7 +624,7 @@ func do_reload(ch *Character, arguments string) {
 
 func (game *Game) InitScripting() error {
 	game.vm = goja.New()
-	game.eventHandlers = make(map[string]*LinkedList)
+	game.eventHandlers = make(map[string]*LinkedList[interface{}])
 
 	game.vm.SetFieldNameMapper(goja.TagFieldNameMapper("json", true))
 
@@ -633,7 +633,7 @@ func (game *Game) InitScripting() error {
 	obj.Set("game", game.vm.ToValue(game))
 
 	obj.Set("clearAllEventHandlers", game.vm.ToValue(func() goja.Value {
-		game.eventHandlers = make(map[string]*LinkedList)
+		game.eventHandlers = make(map[string]*LinkedList[interface{}])
 
 		return game.vm.ToValue(true)
 	}))
@@ -659,7 +659,7 @@ func (game *Game) InitScripting() error {
 	obj.Set("registerEventHandler", game.vm.ToValue(func(name goja.Value, fn goja.Callable) goja.Value {
 		eventName := name.String()
 		if game.eventHandlers[eventName] == nil {
-			game.eventHandlers[eventName] = NewLinkedList()
+			game.eventHandlers[eventName] = NewAnyLinkedList()
 		}
 
 		handler := &EventHandler{name: eventName, callback: fn}
@@ -834,7 +834,7 @@ func (game *Game) InitScripting() error {
 	terrainTypes.Set("TerrainTypeSnowcappedMountains", game.vm.ToValue(TerrainTypeSnowcappedMountains))
 
 	utilObj := game.vm.NewObject()
-	utilObj.Set("createLinkedList", game.vm.ToValue(NewLinkedList))
+	utilObj.Set("createLinkedList", game.vm.ToValue(NewAnyLinkedList))
 	utilObj.Set("createQuadTree", game.vm.ToValue(NewQuadTree))
 	utilObj.Set("newRect2D", game.vm.ToValue(NewRect))
 	utilObj.Set("newPoint2D", game.vm.ToValue(NewPoint))

--- a/src/scripting.go
+++ b/src/scripting.go
@@ -340,7 +340,7 @@ func (game *Game) clearScriptBindings() {
 	}
 
 	for iter := game.Planes.Head; iter != nil; iter = iter.Next {
-		plane := iter.Value.(*Plane)
+		plane := iter.Value
 		plane.Scripts = nil
 	}
 }
@@ -379,7 +379,7 @@ func (game *Game) detachScriptBindings(script *Script) {
 	}
 
 	for iter := game.Planes.Head; iter != nil; iter = iter.Next {
-		plane := iter.Value.(*Plane)
+		plane := iter.Value
 		if sameScriptBinding(plane.Scripts, script) {
 			plane.Scripts = nil
 		}
@@ -493,7 +493,7 @@ func (game *Game) CreateScript(name string, initialBody string) (*Script, error)
 
 func (game *Game) scriptTimersUpdate() {
 	for iter := game.ScriptTimers.Head; iter != nil; iter = iter.Next {
-		effect := iter.Value.(*ScriptTimer)
+		effect := iter.Value
 
 		if time.Since(effect.createdAt).Milliseconds() > effect.delay {
 			_, err := effect.callback(game.vm.ToValue(effect))
@@ -533,7 +533,7 @@ func (game *Game) InvokeNamedEventHandlersWithContextAndArguments(name string, t
 		i := 0
 
 		for iter := game.eventHandlers[name].Head; iter != nil; iter = iter.Next {
-			eventHandler := iter.Value.(*EventHandler)
+			eventHandler := iter.Value
 
 			result, err := eventHandler.callback(this, arguments...)
 			if err != nil {
@@ -624,7 +624,7 @@ func do_reload(ch *Character, arguments string) {
 
 func (game *Game) InitScripting() error {
 	game.vm = goja.New()
-	game.eventHandlers = make(map[string]*LinkedList[interface{}])
+	game.eventHandlers = make(map[string]*LinkedList[*EventHandler])
 
 	game.vm.SetFieldNameMapper(goja.TagFieldNameMapper("json", true))
 
@@ -633,7 +633,7 @@ func (game *Game) InitScripting() error {
 	obj.Set("game", game.vm.ToValue(game))
 
 	obj.Set("clearAllEventHandlers", game.vm.ToValue(func() goja.Value {
-		game.eventHandlers = make(map[string]*LinkedList[interface{}])
+		game.eventHandlers = make(map[string]*LinkedList[*EventHandler])
 
 		return game.vm.ToValue(true)
 	}))
@@ -659,7 +659,7 @@ func (game *Game) InitScripting() error {
 	obj.Set("registerEventHandler", game.vm.ToValue(func(name goja.Value, fn goja.Callable) goja.Value {
 		eventName := name.String()
 		if game.eventHandlers[eventName] == nil {
-			game.eventHandlers[eventName] = NewAnyLinkedList()
+			game.eventHandlers[eventName] = NewLinkedList[*EventHandler]()
 		}
 
 		handler := &EventHandler{name: eventName, callback: fn}

--- a/src/shop.go
+++ b/src/shop.go
@@ -22,10 +22,10 @@ type ShopListing struct {
 }
 
 type Shop struct {
-	Game     *Game                    `json:"game"`
-	Id       int                      `json:"id"`
-	MobileId uint                     `json:"mobileId"`
-	Listings *LinkedList[interface{}] `json:"listings"`
+	Game     *Game                     `json:"game"`
+	Id       int                       `json:"id"`
+	MobileId uint                      `json:"mobileId"`
+	Listings *LinkedList[*ShopListing] `json:"listings"`
 }
 
 func (game *Game) LoadShops() error {
@@ -49,7 +49,7 @@ func (game *Game) LoadShops() error {
 	defer rows.Close()
 
 	for rows.Next() {
-		shop := &Shop{Game: game, Listings: NewAnyLinkedList()}
+		shop := &Shop{Game: game, Listings: NewLinkedList[*ShopListing]()}
 		err := rows.Scan(&shop.Id, &shop.MobileId)
 		if err != nil {
 			log.Printf("Unable to scan shop: %v.\r\n", err)
@@ -133,7 +133,7 @@ func (game *Game) LoadShops() error {
 
 	for _, shop := range game.shops {
 		for iter := shop.Listings.Head; iter != nil; iter = iter.Next {
-			listing := iter.Value.(*ShopListing)
+			listing := iter.Value
 
 			obj, ok := objectFromId[shopListingIds[listing.Id]]
 			if !ok {
@@ -211,7 +211,7 @@ func do_buy(ch *Character, arguments string) {
 	var count int = 1
 
 	for iter := shop.Listings.Head; iter != nil; iter = iter.Next {
-		listing := iter.Value.(*ShopListing)
+		listing := iter.Value
 
 		if listing.Object == nil {
 			continue
@@ -297,7 +297,7 @@ func do_shop(ch *Character, arguments string) {
 	}
 
 	for iter := shop.Listings.Head; iter != nil; iter = iter.Next {
-		listing := iter.Value.(*ShopListing)
+		listing := iter.Value
 
 		if listing.Object == nil {
 			continue

--- a/src/shop.go
+++ b/src/shop.go
@@ -158,7 +158,7 @@ func (ch *Character) FindShopInRoom() *Shop {
 	}
 
 	for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch.Flags&CHAR_SHOPKEEPER != 0 {
 			shop, ok := ch.Game.mobileShops[uint(rch.Id)]
@@ -260,7 +260,7 @@ func do_buy(ch *Character, arguments string) {
 			}
 
 			for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if !rch.IsEqual(ch) {
 					if quantity == 1 {

--- a/src/shop.go
+++ b/src/shop.go
@@ -22,10 +22,10 @@ type ShopListing struct {
 }
 
 type Shop struct {
-	Game     *Game       `json:"game"`
-	Id       int         `json:"id"`
-	MobileId uint        `json:"mobileId"`
-	Listings *LinkedList `json:"listings"`
+	Game     *Game                    `json:"game"`
+	Id       int                      `json:"id"`
+	MobileId uint                     `json:"mobileId"`
+	Listings *LinkedList[interface{}] `json:"listings"`
 }
 
 func (game *Game) LoadShops() error {
@@ -49,7 +49,7 @@ func (game *Game) LoadShops() error {
 	defer rows.Close()
 
 	for rows.Next() {
-		shop := &Shop{Game: game, Listings: NewLinkedList()}
+		shop := &Shop{Game: game, Listings: NewAnyLinkedList()}
 		err := rows.Scan(&shop.Id, &shop.MobileId)
 		if err != nil {
 			log.Printf("Unable to scan shop: %v.\r\n", err)

--- a/src/skills.go
+++ b/src/skills.go
@@ -197,7 +197,7 @@ func do_practice(ch *Character, arguments string) {
 		}
 
 		for iter := ch.Room.Characters.Head; iter != nil; iter = iter.Next {
-			rch := iter.Value.(*Character)
+			rch := iter.Value
 
 			if rch.Flags&CHAR_PRACTICE != 0 {
 				trainerFound = true

--- a/src/skills.go
+++ b/src/skills.go
@@ -110,7 +110,7 @@ func (ch *Character) FindProficiencyByName(name string) *Proficiency {
 
 func (ch *Character) syncJobSkills() error {
 	for iter := ch.Job.Skills.Head; iter != nil; iter = iter.Next {
-		jobSkill := iter.Value.(*JobSkill)
+		jobSkill := iter.Value
 
 		if uint(jobSkill.Level) > ch.Level {
 			continue
@@ -375,7 +375,7 @@ func (ch *Character) LoadPlayerSkills() error {
 		}
 
 		for iter := Jobs.Head; iter != nil; iter = iter.Next {
-			job := iter.Value.(*Job)
+			job := iter.Value
 
 			if job.Id == jobId {
 				proficiency.Job = job

--- a/src/update.go
+++ b/src/update.go
@@ -15,7 +15,7 @@ import (
 
 func (game *Game) characterUpdate() {
 	for iter := game.Characters.Head; iter != nil; iter = iter.Next {
-		ch := iter.Value.(*Character)
+		ch := iter.Value
 
 		if ch.Casting != nil {
 			ch.onCastingUpdate()
@@ -47,7 +47,7 @@ func (game *Game) objectUpdate() {
 
 	for iter := game.Objects.Head; iter != nil; {
 		next := iter.Next
-		obj := iter.Value.(*ObjectInstance)
+		obj := iter.Value
 
 		/* Remove the obj after its ttl time in minutes, if the ITEM_DECAYS flag is set */
 		if obj.shouldDecay(now) {
@@ -115,7 +115,7 @@ func (game *Game) removeCharacterFromWorld(ch *Character) {
 
 	for iter := game.Fights.Head; iter != nil; {
 		next := iter.Next
-		combat := iter.Value.(*Combat)
+		combat := iter.Value
 
 		for _, participant := range combat.Participants {
 			if participant == ch {
@@ -128,7 +128,7 @@ func (game *Game) removeCharacterFromWorld(ch *Character) {
 	}
 
 	for iter := game.Characters.Head; iter != nil; iter = iter.Next {
-		rch := iter.Value.(*Character)
+		rch := iter.Value
 
 		if rch.Fighting == ch {
 			rch.Fighting = nil
@@ -298,7 +298,7 @@ func (obj *ObjectInstance) removeFromLocation() {
 
 func (game *Game) Update() {
 	for iter := game.Characters.Head; iter != nil; iter = iter.Next {
-		ch := iter.Value.(*Character)
+		ch := iter.Value
 
 		ch.onUpdate()
 	}
@@ -306,7 +306,7 @@ func (game *Game) Update() {
 
 func (game *Game) ZoneUpdate() {
 	for iter := game.Zones.Head; iter != nil; iter = iter.Next {
-		zone := iter.Value.(*Zone)
+		zone := iter.Value
 
 		if time.Since(zone.LastReset).Minutes() > float64(zone.ResetFrequency) {
 			game.ResetZone(zone)

--- a/src/update.go
+++ b/src/update.go
@@ -238,7 +238,7 @@ func (game *Game) moveDecayedContainerContent(obj *ObjectInstance, location obje
 		game.moveDecayedContainerContentToCarrier(obj, location.carrier)
 	case location.container != nil:
 		if location.container.Contents == nil {
-			location.container.Contents = NewLinkedList()
+			location.container.Contents = NewAnyLinkedList()
 		}
 
 		location.container.AddObject(obj)

--- a/src/update.go
+++ b/src/update.go
@@ -23,7 +23,7 @@ func (game *Game) characterUpdate() {
 
 		for effectIter := ch.Effects.Head; effectIter != nil; {
 			next := effectIter.Next
-			fx := effectIter.Value.(*Effect)
+			fx := effectIter.Value
 
 			if fx.Duration != EffectDurationPermanent && int(time.Since(fx.CreatedAt).Seconds()) >= fx.Duration {
 				if fx.OnComplete != nil {
@@ -144,7 +144,7 @@ func (game *Game) removeObjectFromWorld(obj *ObjectInstance) {
 	if obj.Contents != nil {
 		for iter := obj.Contents.Head; iter != nil; {
 			next := iter.Next
-			containedObj := iter.Value.(*ObjectInstance)
+			containedObj := iter.Value
 
 			game.removeObjectFromWorld(containedObj)
 			iter = next
@@ -166,7 +166,7 @@ func (game *Game) sendDecayMessage(obj *ObjectInstance, location objectLocation)
 
 	if location.room != nil {
 		for innerIter := location.room.Characters.Head; innerIter != nil; innerIter = innerIter.Next {
-			rch := innerIter.Value.(*Character)
+			rch := innerIter.Value
 
 			rch.Send(fmt.Sprintf("{D%s{D crumbles into dust.{x\r\n", obj.GetShortDescriptionUpper(rch)))
 		}
@@ -184,7 +184,7 @@ func (game *Game) moveDecayedContainerContents(container *ObjectInstance, locati
 
 	for contentIter := container.Contents.Head; contentIter != nil; {
 		next := contentIter.Next
-		contentObj := contentIter.Value.(*ObjectInstance)
+		contentObj := contentIter.Value
 
 		container.removeObject(contentObj)
 		game.moveDecayedContainerContent(contentObj, location)
@@ -238,7 +238,7 @@ func (game *Game) moveDecayedContainerContent(obj *ObjectInstance, location obje
 		game.moveDecayedContainerContentToCarrier(obj, location.carrier)
 	case location.container != nil:
 		if location.container.Contents == nil {
-			location.container.Contents = NewAnyLinkedList()
+			location.container.Contents = NewLinkedList[*ObjectInstance]()
 		}
 
 		location.container.AddObject(obj)
@@ -251,7 +251,7 @@ func (game *Game) moveDecayedContainerContentToRoom(obj *ObjectInstance, room *R
 	var found *ObjectInstance = nil
 
 	for iter := room.Objects.Head; iter != nil; iter = iter.Next {
-		roomObj := iter.Value.(*ObjectInstance)
+		roomObj := iter.Value
 
 		if roomObj.ItemType == ItemTypeCurrency {
 			found = roomObj

--- a/src/zone.go
+++ b/src/zone.go
@@ -125,14 +125,14 @@ func (game *Game) CreateZone() *Zone {
 
 func (game *Game) ResetRoom(room *Room) {
 	for iter := room.Resets.Head; iter != nil; iter = iter.Next {
-		reset := iter.Value.(*Reset)
+		reset := iter.Value
 
 		switch reset.ResetType {
 		case ResetTypeObject:
 			count := 0
 
 			for iter := room.Objects.Head; iter != nil; iter = iter.Next {
-				obj := iter.Value.(*ObjectInstance)
+				obj := iter.Value
 
 				if obj.ParentId == uint(reset.Value0) {
 					count++
@@ -161,7 +161,7 @@ func (game *Game) ResetRoom(room *Room) {
 			count := 0
 
 			for iter := room.Characters.Head; iter != nil; iter = iter.Next {
-				rch := iter.Value.(*Character)
+				rch := iter.Value
 
 				if rch.Flags&CHAR_IS_PLAYER == 0 && rch.Id == reset.Value0 {
 					count++
@@ -189,7 +189,7 @@ func (game *Game) ResetRoom(room *Room) {
 	}
 
 	for iter := room.Characters.Head; iter != nil; iter = iter.Next {
-		character := iter.Value.(*Character)
+		character := iter.Value
 
 		if room.Zone.ResetMessage != "" && character.Flags&CHAR_IS_PLAYER != 0 {
 			character.Send(fmt.Sprintf("\r\n{x%s{x\r\n", room.Zone.ResetMessage))
@@ -293,9 +293,9 @@ func (zone *Zone) CreateRoom() (*Room, error) {
 	room.Flags = 0
 	room.Description = "This room-in-development needs a description!"
 	room.Exit = make(map[uint]*Exit)
-	room.Characters = NewAnyLinkedList()
-	room.Objects = NewAnyLinkedList()
-	room.Resets = NewAnyLinkedList()
+	room.Characters = NewLinkedList[*Character]()
+	room.Objects = NewLinkedList[*ObjectInstance]()
+	room.Resets = NewLinkedList[*Reset]()
 
 	_, err = tx.Exec(`
 		INSERT INTO

--- a/src/zone.go
+++ b/src/zone.go
@@ -293,9 +293,9 @@ func (zone *Zone) CreateRoom() (*Room, error) {
 	room.Flags = 0
 	room.Description = "This room-in-development needs a description!"
 	room.Exit = make(map[uint]*Exit)
-	room.Characters = NewLinkedList()
-	room.Objects = NewLinkedList()
-	room.Resets = NewLinkedList()
+	room.Characters = NewAnyLinkedList()
+	room.Objects = NewAnyLinkedList()
+	room.Resets = NewAnyLinkedList()
 
 	_, err = tx.Exec(`
 		INSERT INTO
@@ -366,7 +366,7 @@ func (zone *Zone) FindAvailableRoomID() (int, error) {
 func (game *Game) LoadZones() error {
 	log.Printf("Loading zones.\r\n")
 
-	game.Zones = NewLinkedList()
+	game.Zones = NewAnyLinkedList()
 
 	rows, err := game.db.Query(`
 		SELECT

--- a/src/zone.go
+++ b/src/zone.go
@@ -207,7 +207,7 @@ func (game *Game) ValidZoneRangeExcept(low uint, high uint, ignoredZoneId int) b
 	}
 
 	for zoneIter := game.Zones.Head; zoneIter != nil; zoneIter = zoneIter.Next {
-		zone := zoneIter.Value.(*Zone)
+		zone := zoneIter.Value
 
 		if zone.Id == ignoredZoneId {
 			continue
@@ -366,7 +366,7 @@ func (zone *Zone) FindAvailableRoomID() (int, error) {
 func (game *Game) LoadZones() error {
 	log.Printf("Loading zones.\r\n")
 
-	game.Zones = NewAnyLinkedList()
+	game.Zones = NewLinkedList[*Zone]()
 
 	rows, err := game.db.Query(`
 		SELECT
@@ -490,7 +490,7 @@ func (game *Game) LoadResets() error {
 
 func (game *Game) FindZoneByID(id int) *Zone {
 	for zoneIter := game.Zones.Head; zoneIter != nil; zoneIter = zoneIter.Next {
-		zone := zoneIter.Value.(*Zone)
+		zone := zoneIter.Value
 
 		if zone.Id == id {
 			return zone


### PR DESCRIPTION
Golem preceded the availability of generics in Go, so I've now gone back to update its linked list implementation to use them. 

- `LinkedList` is now generic
- Includes a small set of unit tests for lists
- Where previously everything stored in a linked list node lost their values' typing to `interface{}` to be manually casted back later, that's now only the case for a few exceptions (such as the boundary with Goja for JavaScript consumers of lists)